### PR TITLE
chore: PNP actions - add reuse release option

### DIFF
--- a/.github/workflows/pnp-build-input-api-v2.yml
+++ b/.github/workflows/pnp-build-input-api-v2.yml
@@ -382,5 +382,6 @@ jobs:
       
       - name: Update JIRA release notes
         uses: extenda/actions/jira-releasenotes@v0
+        continue-on-error: true
         with:
           jira-project: EA

--- a/.github/workflows/pnp-build-input-api.yml
+++ b/.github/workflows/pnp-build-input-api.yml
@@ -388,5 +388,6 @@ jobs:
       
       - name: Update JIRA release notes
         uses: extenda/actions/jira-releasenotes@v0
+        continue-on-error: true
         with:
           jira-project: EA

--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -301,7 +301,7 @@ jobs:
         run: |
           gcloud container images add-tag \
             eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
-            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ release_version }}
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ env.release_version }}
         env:
           release_version: ${{ inputs.reuse-release == false && steps.release.outputs.version || steps.release_reuse.outputs.version }}
 

--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -324,7 +324,7 @@ jobs:
           channel: ${{ secrets.slack-channel }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
-  jira-release-notes:
+  jira-release-notes:    
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs:
@@ -341,5 +341,6 @@ jobs:
       
       - name: Update JIRA release notes
         uses: extenda/actions/jira-releasenotes@v0
+        continue-on-error: true
         with:
           jira-project: EA

--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -341,6 +341,5 @@ jobs:
       
       - name: Update JIRA release notes
         uses: extenda/actions/jira-releasenotes@v0
-        continue-on-error: true
         with:
           jira-project: EA

--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -63,6 +63,11 @@ on:
         type: boolean
         required: false
         default: false
+      reuse-release:
+        description: 'If true, instead of creating new release reuses the current one. Intended to be used in config-based multi-service deploy scenarios, when multiple service instances created from the same code base.'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build:
@@ -273,8 +278,17 @@ jobs:
         with:
           fetch-depth: 0
 
+
       - name: Create release
+        if: ${{ inputs.reuse-release == false }}
         uses: extenda/actions/conventional-release@v0
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release (reuse current release mode)
+        if: ${{ inputs.reuse-release == true }}
+        uses: extenda/actions/conventional-version@v0
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -290,7 +304,7 @@ jobs:
             eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ steps.release.outputs.version }}
 
       - name: Create Pact STAGING release
-        if: ${{ inputs.do-pact-consumer-tests == true }}
+        if: ${{ inputs.do-pact-consumer-tests == true && inputs.reuse-release == false }}
         uses: extenda/actions/pact-tag-version@v0
         with:
           service-account-key: ${{ secrets.SECRET_AUTH }}

--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -301,7 +301,7 @@ jobs:
         run: |
           gcloud container images add-tag \
             eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
-            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ $release_version }}
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ release_version }}
         env:
           release_version: ${{ inputs.reuse-release == false && steps.release.outputs.version || steps.release_reuse.outputs.version }}
 

--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -301,9 +301,9 @@ jobs:
         run: |
           gcloud container images add-tag \
             eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
-            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ $version }}
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ $release_version }}
         env:
-          release-version: ${{ inputs.reuse-release == false && steps.release.outputs.version || steps.release_reuse.outputs.version }}
+          release_version: ${{ inputs.reuse-release == false && steps.release.outputs.version || steps.release_reuse.outputs.version }}
 
       - name: Create Pact STAGING release
         if: ${{ inputs.do-pact-consumer-tests == true && inputs.reuse-release == false }}

--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -289,7 +289,7 @@ jobs:
       - name: Create release (reuse current release mode)
         if: ${{ inputs.reuse-release == true }}
         uses: extenda/actions/conventional-version@v0
-        id: release
+        id: release_reuse
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -301,7 +301,9 @@ jobs:
         run: |
           gcloud container images add-tag \
             eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
-            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ steps.release.outputs.version }}
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ $version }}
+        env:
+          release-version: ${{ inputs.reuse-release == false && steps.release.outputs.version || steps.release_reuse.outputs.version }}
 
       - name: Create Pact STAGING release
         if: ${{ inputs.do-pact-consumer-tests == true && inputs.reuse-release == false }}

--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -341,5 +341,6 @@ jobs:
       
       - name: Update JIRA release notes
         uses: extenda/actions/jira-releasenotes@v0
+        continue-on-error: true
         with:
           jira-project: EA

--- a/.github/workflows/pnp-build-query-api.yml
+++ b/.github/workflows/pnp-build-query-api.yml
@@ -335,6 +335,7 @@ jobs:
       
       - name: Update JIRA release notes
         uses: extenda/actions/jira-releasenotes@v0
+        continue-on-error: true
         with:
           jira-project: EA
 
@@ -355,5 +356,6 @@ jobs:
       
       - name: Update JIRA release notes
         uses: extenda/actions/jira-releasenotes@v0
+        continue-on-error: true
         with:
           jira-project: EA

--- a/.github/workflows/pnp-build-sink.yml
+++ b/.github/workflows/pnp-build-sink.yml
@@ -234,5 +234,6 @@ jobs:
       
       - name: Update JIRA release notes
         uses: extenda/actions/jira-releasenotes@v0
+        continue-on-error: true
         with:
           jira-project: EA


### PR DESCRIPTION
- Adds "reuse-release" parameter to the "pnp-build-processor" action, which instead of calling "conventional-release" uses the "conventional-version", effectively reusing the current version for the build. This parameter is intended to be used in multi-service deployment scenarios, where we generate artifacts for several services using the same code base. For such situation, the multi-service-deploy workflow file will use first "pnp-build-processor" in normal mode (i.e. reuse-release" = false, whish is default) and all subsequent calls to build-processor will have this parameter set to true.

- Adds "continue-on-error" to all usages of jira-release notes, because that action ends up with multiple "false" errors on execution, making all the workflow fail. This is especially problematic for multi-service-deployments described above, but also generates lots of false build errors. Thus ignoring this action failings until it'll be stabilized.