### PR TITLE
chore: Fix sonar analysis steps in pnp workflows

### DIFF
--- a/.github/workflows/pnp-build-input-api-v2.yml
+++ b/.github/workflows/pnp-build-input-api-v2.yml
@@ -112,7 +112,6 @@ jobs:
         with:
           sonar-host: https://sonarcloud.io
           sonar-scanner: dotnet
-          main-branch: ${{ steps.semver.outputs.branch-name-short }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
       - name: Build dotnet solution
@@ -140,7 +139,6 @@ jobs:
         with:
           sonar-host: https://sonarcloud.io
           sonar-scanner: dotnet
-          main-branch: ${{ steps.semver.outputs.branch-name-short }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
       - name: Create/update pact version

--- a/.github/workflows/pnp-build-input-api.yml
+++ b/.github/workflows/pnp-build-input-api.yml
@@ -111,7 +111,6 @@ jobs:
         with:
           sonar-host: https://sonarcloud.io
           sonar-scanner: dotnet
-          main-branch: ${{ steps.semver.outputs.branch-name-short }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
       - name: Build dotnet solution
@@ -139,7 +138,6 @@ jobs:
         with:
           sonar-host: https://sonarcloud.io
           sonar-scanner: dotnet
-          main-branch: ${{ steps.semver.outputs.branch-name-short }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
       - name: Create/update pact version

--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -124,7 +124,6 @@ jobs:
         uses: extenda/actions/sonar-scanner@v0
         with:
           sonar-host: https://sonarcloud.io
-          main-branch: master
           maven-args: --file ${{ secrets.path-to-pom }} --settings settings.xml org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar
           service-account-key: ${{ secrets.SECRET_AUTH }}
       

--- a/.github/workflows/pnp-build-query-api.yml
+++ b/.github/workflows/pnp-build-query-api.yml
@@ -93,7 +93,6 @@ jobs:
         with:
           sonar-host: https://sonarcloud.io
           sonar-scanner: dotnet
-          main-branch: ${{ steps.semver.outputs.branch-name-short }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
       - name: Build dotnet solution
@@ -109,7 +108,6 @@ jobs:
         with:
           sonar-host: https://sonarcloud.io
           sonar-scanner: dotnet
-          main-branch: ${{ steps.semver.outputs.branch-name-short }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
       
       - name: Notify Slack if failed

--- a/.github/workflows/pnp-build-sink.yml
+++ b/.github/workflows/pnp-build-sink.yml
@@ -78,7 +78,6 @@ jobs:
         with:
           sonar-host: https://sonarcloud.io
           sonar-scanner: dotnet
-          main-branch: ${{ steps.semver.outputs.branch-name-short }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
       - name: Build dotnet solution
@@ -94,7 +93,6 @@ jobs:
         with:
           sonar-host: https://sonarcloud.io
           sonar-scanner: dotnet
-          main-branch: ${{ steps.semver.outputs.branch-name-short }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
       - name: Notify Slack if failed


### PR DESCRIPTION
Got the following message from Samuel:
> Looks like you’re using sonar incorrectly.
```
- name: Analyze with Sonar  
        uses: extenda/actions/sonar-scanner@v0
        with:
          sonar-host: https://sonarcloud.io/
          sonar-scanner: dotnet
          main-branch: ${{ steps.semver.outputs.branch-name-short }}
          service-account-key: ${{ secrets.SECRET_AUTH }}
```
> I think the main-branch argument as defined here will change the main to point to the current PR. This will mess up your quality gates. The main branch should be a static value, typically master unless a gitflow workflow is used when develop is main.
> Could you try to change this and see if your coverage still works as you expect? Right now I’m worried you don’t really have a long term quality gate.