### PR TITLE
chore: Fix PNP multi-service workflow

### DIFF
--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -68,6 +68,10 @@ on:
         type: boolean
         required: false
         default: false
+      release-version:
+        description: 'Instead of creating new release reuse this on. Intended to be used in config-based multi-service deploy scenarios, when multiple service instances created from the same code base.'
+        type: string
+        required: false
 
 jobs:
   build:
@@ -285,13 +289,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create release (reuse current release mode)
-        if: ${{ inputs.reuse-release == true }}
-        uses: extenda/actions/conventional-version@v0
-        id: release_reuse
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: extenda/actions/setup-gcloud@v0
         with:
           service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
@@ -302,7 +299,7 @@ jobs:
             eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
             eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ env.release_version }}
         env:
-          release_version: ${{ inputs.reuse-release == false && steps.release.outputs.version || steps.release_reuse.outputs.version }}
+          release_version: ${{ inputs.reuse-release == false && steps.release.outputs.version || inputs.release-version }}
 
       - name: Create Pact STAGING release
         if: ${{ inputs.do-pact-consumer-tests == true && inputs.reuse-release == false }}

--- a/.github/workflows/pnp-build-processor.yml
+++ b/.github/workflows/pnp-build-processor.yml
@@ -68,10 +68,6 @@ on:
         type: boolean
         required: false
         default: false
-      release-version:
-        description: 'Instead of creating new release reuse this on. Intended to be used in config-based multi-service deploy scenarios, when multiple service instances created from the same code base.'
-        type: string
-        required: false
 
 jobs:
   build:
@@ -289,6 +285,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Create release (reuse current release mode)
+        if: ${{ inputs.reuse-release == true }}
+        uses: extenda/actions/conventional-version@v0
+        id: release_reuse
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: extenda/actions/setup-gcloud@v0
         with:
           service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
@@ -299,7 +302,7 @@ jobs:
             eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
             eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ env.release_version }}
         env:
-          release_version: ${{ inputs.reuse-release == false && steps.release.outputs.version || inputs.release-version }}
+          release_version: ${{ inputs.reuse-release == false && steps.release.outputs.version || steps.release_reuse.outputs.release-version }}
 
       - name: Create Pact STAGING release
         if: ${{ inputs.do-pact-consumer-tests == true && inputs.reuse-release == false }}


### PR DESCRIPTION
In its outputs the "conventional-version" action fills the "outputs.version" field with next projected version, which in multi-project deployments like recalculation service, where release is done in the build of the one of the projects and others reusing it, like:
build: recalc-item => build: recalc-price-specification
                             => build: recalc-item-link
                             => build: recalc-item-identifier
led to the "second wave" builds having the next version, comparing with "first". I.e.
item: 0.35.0, price-spec, item-identifier, item-link: 0.36.0
which caused issues later, when trying to publish to production, namely for "second wave" services, the previous (comparing to what's expected to be deployed) version of the service reaching the prod.

Using the release-version field allows to use version of the latest release (for recalc processor it would be item-recalc) for "second wave" builds".