### PR TITLE
chore: Add v2 version of build workflow for PnP Query APIs

### DIFF
--- a/.github/workflows/pnp-build-query-api-v2.yml
+++ b/.github/workflows/pnp-build-query-api-v2.yml
@@ -26,7 +26,7 @@ on:
         required: true
     inputs:
       has-k6-tests:
-        description: 'If true runs k6 tests for this API. Requires "k6-node-version", "k6-tests-root-folder", "k6-tests-filenames" to run k6 tests'     
+        description: 'If true runs k6 tests for this API. Requires "k6-tests-root-folder" and "k6-tests-filenames" to run k6 tests'     
         required: true
         type: boolean
       k6-node-version:
@@ -39,14 +39,15 @@ on:
         default: 'test/k6'
         type: string
         required: false
-      k6-tests-filenames:
+      k6-tests-file-names:
         description: 'k6 tests'
-        default: "['dist/api-tests-v1.js','dist/api-tests-v2.js']"
+        default: '["dist/api-tests-v1.js", "dist/api-tests-v2.js"]'
         type: string
         required: false
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -203,7 +204,7 @@ jobs:
     #   - staging
     strategy:
       matrix:
-        k6-test: ${{ fromJSON(inputs.k6-tests-filenames) }}
+        k6-test-file-name: ${{ fromJSON(inputs.k6-tests-file-names) }}
 
     steps:
       - uses: actions/checkout@v2
@@ -234,7 +235,7 @@ jobs:
       - name: Run API tests
         uses: k6io/action@v0.2.0
         with:
-          filename: ${{ inputs.k6-tests-root-folder }}/${{ matrix.k6-test }}
+          filename: ${{ inputs.k6-tests-root-folder }}/${{ matrix.k6-test-file-name }}
           flags: --env IAM_TOKEN=${{ steps.testtoken.outputs.iam-token }} --env SERVICE_BASE_URL=${{ secrets.staging-service-base-url }}
 
       - name: Notify Slack if failed

--- a/.github/workflows/pnp-build-query-api-v2.yml
+++ b/.github/workflows/pnp-build-query-api-v2.yml
@@ -1,0 +1,319 @@
+name: Build and Deploy
+on:
+  workflow_call:
+    secrets:
+      GCR_image_name:
+        description: 'A name of the image to be created in GCR'
+        required: true
+      path-to-sln:
+        description: 'Path to the sln file'
+        required: true
+      path-to-unit-tests:
+        description: 'Path to sln or unit tests csproj file.'
+        required: true
+      path-to-dockerfile:
+        description: 'Path to dockerfile which builds the API.'
+        required: true
+      staging-service-base-url:
+        description: 'A url of the service in staging'
+        required: false
+      slack-channel:
+        description: 'A slack channel which needs to be notified in case of failure'
+        required: false
+      SECRET_AUTH:
+        required: true
+      GCLOUD_AUTH_STAGING:
+        required: true
+    inputs:
+      has-k6-tests:
+        description: 'If true runs k6 tests for this API. Requires "k6-node-version", "k6-tests-root-folder", "k6-tests-filenames" to run k6 tests'     
+        required: true
+        type: boolean
+      k6-node-version:
+        description: 'Node version needed for k6'
+        type: number
+        required: false
+        default: 14
+      k6-tests-root-folder:
+        description: 'k6 tests root folder'
+        default: 'test/k6'
+        type: string
+        required: false
+      k6-tests-filenames:
+        description: 'k6 tests'
+        default: "['dist/api-tests-v1.js','dist/api-tests-v2.js']"
+        type: string
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: extenda/actions/gcp-secret-manager@v0
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          secrets: |
+            NEXUS_PASSWORD: nexus-password
+            NEXUS_USERNAME: nexus-username
+            NUGET_API_KEY: nuget-api-key  
+            STYRA_TOKEN: styra-das-token                            
+        
+      - name: Determine version
+        uses: extenda/actions/conventional-version@v0
+        id: semver
+        with:
+          build-number: ${{ github.run_number }}
+      
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1
+        with:
+          nuget-version: 'latest'
+
+      - name: Setup NuGet sources
+        uses: extenda/actions/setup-nuget-sources@v0
+        with:
+          config-file: src/nuget.config # Check this in all the build files
+          sources: |
+            [{
+              "name": "nuget.org",
+              "source": "https://api.nuget.org/v3/index.json"
+            },
+            {
+              "name": "Extenda",
+              "source": "https://repo.extendaretail.com/repository/nuget-hosted/index.json",
+              "username": "${{ env.NEXUS_USERNAME }}",
+              "password": "${{ env.NEXUS_PASSWORD }}",
+              "apikey": "${{ env.NUGET_API_KEY }}"
+            }]
+
+      - name: Start Sonar Scanner
+        uses: extenda/actions/sonar-scanner@v0
+        with:
+          sonar-host: https://sonarcloud.io
+          sonar-scanner: dotnet
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+
+      - name: Build dotnet solution
+        run: |
+          dotnet build ${{ secrets.path-to-sln }} --configuration Release /p:Version=${{ steps.semver.outputs.semver }}
+      
+      - name: Test dotnet solution
+        run: |
+          dotnet test ${{ secrets.path-to-unit-tests }} /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+
+      - name: Analyze with Sonar  
+        uses: extenda/actions/sonar-scanner@v0
+        with:
+          sonar-host: https://sonarcloud.io
+          sonar-scanner: dotnet
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+      
+      - name: Notify Slack if failed
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        uses: extenda/actions/slack-notify@v0
+        with:
+          text: |
+            *Build failed for ${{ github.repository }}: ${{ github.workflow }}* :heavy_exclamation_mark:
+            Build failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{github.job}}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
+          channel: ${{ secrets.slack-channel }}
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+
+  staging:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2 
+
+      - uses: extenda/actions/gcp-secret-manager@v0
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          secrets: |
+            NEXUS_PASSWORD: nexus-password
+            NEXUS_USERNAME: nexus-username
+            NUGET_API_KEY: nuget-api-key
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1
+        with:
+          nuget-version: 'latest'
+
+      - name: Setup NuGet sources
+        uses: extenda/actions/setup-nuget-sources@v0
+        with:
+          config-file: src/nuget.config # Check this in all the APIs
+          sources: |
+            [{
+              "name": "nuget.org",
+              "source": "https://api.nuget.org/v3/index.json"
+            },
+            {
+              "name": "Extenda",
+              "source": "https://repo.extendaretail.com/repository/nuget-hosted/index.json",
+              "username": "${{ env.NEXUS_USERNAME }}",
+              "password": "${{ env.NEXUS_PASSWORD }}",
+              "apikey": "${{ env.NUGET_API_KEY }}"
+            }]
+
+      - uses: extenda/actions/setup-gcloud@v0
+        with:
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+
+      - name: Build and push Docker
+        run: |
+          gcloud --quiet auth configure-docker
+          IMAGE=eu.gcr.io/extenda/${{ secrets.GCR_image_name }}
+          docker build -t $IMAGE:${{ github.sha }} -t $IMAGE:latest . -f ${{ secrets.path-to-dockerfile }}
+          docker push --all-tags $IMAGE
+
+      - name: Attest image
+        uses: extenda/actions/binary-auth-attestation@v0
+        with:
+          image-path: eu.gcr.io/extenda/${{ secrets.GCR_image_name }}
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+
+      - name: Deploy to staging
+        uses: extenda/actions/cloud-run@v0
+        with:
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+          image: eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }}
+      
+      - name: Notify Slack if failed
+        if: failure()
+        uses: extenda/actions/slack-notify@v0
+        with:
+          text: |
+            *Build failed for ${{ github.repository }}: ${{ github.workflow }}* :heavy_exclamation_mark:
+            Build failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{github.job}}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
+          channel: ${{ secrets.slack-channel }}
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+
+  k6:
+    if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
+    runs-on: ubuntu-latest
+    needs:
+      - staging
+    strategy:
+      matrix:
+        k6-test: ${{ fromJSON(github.event.inputs.k6-tests-filenames) }}
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: extenda/actions/gcp-secret-manager@v0
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          secrets: |
+            API_KEY: api-key-hiidentity-staff
+
+      - name: IAM token
+        id: testtoken
+        uses: extenda/actions/iam-test-token@v0
+        with:
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+          api-key: ${{ env.API_KEY }}
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ inputs.k6-node-version }}
+
+      - name: yarn webpack
+        run: |
+         cd ${{ inputs.k6-tests-root-folder }}
+         yarn install
+         yarn webpack
+    
+      - name: Run API tests
+        uses: k6io/action@v0.2.0
+        with:
+          filename: ${{ inputs.k6-tests-root-folder }}/${{ matrix.k6-test }}
+          flags: --env IAM_TOKEN=${{ steps.testtoken.outputs.iam-token }} --env SERVICE_BASE_URL=${{ secrets.staging-service-base-url }}
+
+      - name: Notify Slack if failed
+        if: failure()
+        uses: extenda/actions/slack-notify@v0
+        with:
+          text: |
+            *Build failed for ${{ github.repository }}: ${{ github.workflow }}* :heavy_exclamation_mark:
+            Build failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{github.job}}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
+          channel: ${{ secrets.slack-channel }}
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+
+  release-after-k6:
+    if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
+    runs-on: ubuntu-latest
+    needs: k6
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create release
+        uses: extenda/actions/conventional-release@v0
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: extenda/actions/setup-gcloud@v0
+        with:
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+
+      - name: Add tag in GCR
+        run: |
+          gcloud container images add-tag \
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ steps.release.outputs.version }}
+      
+      - name: Notify Slack if failed
+        if: failure()
+        uses: extenda/actions/slack-notify@v0
+        with:
+          text: |
+            *Build failed for ${{ github.repository }}: ${{ github.workflow }}* :heavy_exclamation_mark:
+            Build failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{github.job}}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
+          channel: ${{ secrets.slack-channel }}
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+
+  release:
+    if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == false }}
+    runs-on: ubuntu-latest
+    needs: staging
+    outputs:
+      release-tag: ${{ steps.release.outputs.release-tag }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create release
+        uses: extenda/actions/conventional-release@v0
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: extenda/actions/setup-gcloud@v0
+        with:
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+
+      - name: Add tag in GCR
+        run: |
+          gcloud container images add-tag \
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ steps.release.outputs.version }}
+      
+      - name: Notify Slack if failed
+        if: failure()
+        uses: extenda/actions/slack-notify@v0
+        with:
+          text: |
+            *Build failed for ${{ github.repository }}: ${{ github.workflow }}* :heavy_exclamation_mark:
+            Build failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{github.job}}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
+          channel: ${{ secrets.slack-channel }}
+          service-account-key: ${{ secrets.SECRET_AUTH }}

--- a/.github/workflows/pnp-build-query-api-v2.yml
+++ b/.github/workflows/pnp-build-query-api-v2.yml
@@ -67,7 +67,7 @@ jobs:
           build-number: ${{ github.run_number }}
       
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
 
@@ -220,7 +220,7 @@ jobs:
           service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
           api-key: ${{ env.API_KEY }}
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.k6-node-version }}
 
@@ -250,7 +250,6 @@ jobs:
     needs: [build, k6]
     if: |
       always() &&
-      github.ref == 'refs/heads/master' &&
       needs.build.result == 'success' &&
       (inputs.has-k6-tests == false || needs.k6.result == 'success')
     runs-on: ubuntu-latest

--- a/.github/workflows/pnp-build-query-api-v2.yml
+++ b/.github/workflows/pnp-build-query-api-v2.yml
@@ -26,7 +26,7 @@ on:
         required: true
     inputs:
       has-k6-tests:
-        description: 'If true runs k6 tests for this API. Requires "k6-tests-root-folder" and "k6-tests-filenames" to run k6 tests'     
+        description: 'If true runs k6 tests for this API. Requires "k6-tests-root-folder" and "k6-tests-file-names" to run k6 tests'     
         required: true
         type: boolean
       k6-node-version:
@@ -47,10 +47,9 @@ on:
 
 jobs:
   build:
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: extenda/actions/gcp-secret-manager@v0
         with:
@@ -127,11 +126,11 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
   staging:
+    needs: build
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    needs: build
     steps:
-      - uses: actions/checkout@v2 
+      - uses: actions/checkout@v3 
 
       - uses: extenda/actions/gcp-secret-manager@v0
         with:
@@ -197,17 +196,15 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
   k6:
-    #if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
-    if: ${{ inputs.has-k6-tests == true }}
+    needs: staging
+    if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
     runs-on: ubuntu-latest
-    # needs:
-    #   - staging
     strategy:
       matrix:
         k6-test-file-name: ${{ fromJSON(inputs.k6-tests-file-names) }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - uses: extenda/actions/gcp-secret-manager@v0
         with:
@@ -248,49 +245,16 @@ jobs:
           channel: ${{ secrets.slack-channel }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
-  release-after-k6:
-    if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
-    runs-on: ubuntu-latest
-    needs: k6
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Create release
-        uses: extenda/actions/conventional-release@v0
-        id: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: extenda/actions/setup-gcloud@v0
-        with:
-          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
-
-      - name: Add tag in GCR
-        run: |
-          gcloud container images add-tag \
-            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
-            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ steps.release.outputs.version }}
-      
-      - name: Notify Slack if failed
-        if: failure()
-        uses: extenda/actions/slack-notify@v0
-        with:
-          text: |
-            *Build failed for ${{ github.repository }}: ${{ github.workflow }}* :heavy_exclamation_mark:
-            Build failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{github.job}}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
-          channel: ${{ secrets.slack-channel }}
-          service-account-key: ${{ secrets.SECRET_AUTH }}
-
   release:
-    if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == false }}
+    needs: [staging, k6]
+    if: |
+      always() &&
+      github.ref == 'refs/heads/master' &&
+      needs.staging.result == 'success' &&
+      (needs.k6.result == 'success' || needs.k6.result == 'skipped')
     runs-on: ubuntu-latest
-    needs: staging
-    outputs:
-      release-tag: ${{ steps.release.outputs.release-tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pnp-build-query-api-v2.yml
+++ b/.github/workflows/pnp-build-query-api-v2.yml
@@ -196,9 +196,8 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
   k6:
-    if: ${{ inputs.has-k6-tests == true }}
-    needs: build
-    #if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
+    needs: staging
+    if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -247,10 +246,11 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
   release:
-    needs: [build, k6]
+    needs: [staging, k6]
     if: |
       always() &&
-      needs.build.result == 'success' &&
+      github.ref == 'refs/heads/master' &&
+      needs.staging.result == 'success' &&
       (inputs.has-k6-tests == false || needs.k6.result == 'success')
     runs-on: ubuntu-latest
     steps:
@@ -258,21 +258,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      # - name: Create release
-      #   uses: extenda/actions/conventional-release@v0
-      #   id: release
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release
+        uses: extenda/actions/conventional-release@v0
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - uses: extenda/actions/setup-gcloud@v0
-      #   with:
-      #     service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+      - uses: extenda/actions/setup-gcloud@v0
+        with:
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
 
-      # - name: Add tag in GCR
-      #   run: |
-      #     gcloud container images add-tag \
-      #       eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
-      #       eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ steps.release.outputs.version }}
+      - name: Add tag in GCR
+        run: |
+          gcloud container images add-tag \
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ steps.release.outputs.version }}
       
       - name: Notify Slack if failed
         if: failure()

--- a/.github/workflows/pnp-build-query-api-v2.yml
+++ b/.github/workflows/pnp-build-query-api-v2.yml
@@ -196,10 +196,11 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
   k6:
-    if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
+    #if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
+    if: ${{ inputs.has-k6-tests == true }}
     runs-on: ubuntu-latest
-    needs:
-      - staging
+    # needs:
+    #   - staging
     strategy:
       matrix:
         k6-test: ${{ fromJSON(github.event.inputs.k6-tests-filenames) }}

--- a/.github/workflows/pnp-build-query-api-v2.yml
+++ b/.github/workflows/pnp-build-query-api-v2.yml
@@ -27,8 +27,8 @@ on:
     inputs:
       has-k6-tests:
         description: 'If true runs k6 tests for this API. Requires "k6-tests-root-folder" and "k6-tests-file-names" to run k6 tests'     
-        required: true
         type: boolean
+        required: true
       k6-node-version:
         description: 'Node version needed for k6'
         type: number
@@ -36,14 +36,14 @@ on:
         default: 14
       k6-tests-root-folder:
         description: 'k6 tests root folder'
+        type: string
+        required: false
         default: 'test/k6'
-        type: string
-        required: false
       k6-tests-file-names:
-        description: 'k6 tests'
-        default: '["dist/api-tests-v1.js", "dist/api-tests-v2.js"]'
+        description: 'The k6 tests file names. Should follow the JSON string array format.'
         type: string
         required: false
+        default: '["dist/api-tests-v1.js", "dist/api-tests-v2.js"]'
 
 jobs:
   build:
@@ -79,7 +79,7 @@ jobs:
       - name: Setup NuGet sources
         uses: extenda/actions/setup-nuget-sources@v0
         with:
-          config-file: src/nuget.config # Check this in all the build files
+          config-file: src/nuget.config
           sources: |
             [{
               "name": "nuget.org",
@@ -148,7 +148,7 @@ jobs:
       - name: Setup NuGet sources
         uses: extenda/actions/setup-nuget-sources@v0
         with:
-          config-file: src/nuget.config # Check this in all the APIs
+          config-file: src/nuget.config
           sources: |
             [{
               "name": "nuget.org",
@@ -251,7 +251,7 @@ jobs:
       always() &&
       github.ref == 'refs/heads/master' &&
       needs.staging.result == 'success' &&
-      (needs.k6.result == 'success' || needs.k6.result == 'skipped')
+      (inputs.has-k6-tests == false || needs.k6.result == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pnp-build-query-api-v2.yml
+++ b/.github/workflows/pnp-build-query-api-v2.yml
@@ -203,7 +203,7 @@ jobs:
     #   - staging
     strategy:
       matrix:
-        k6-test: ${{ fromJSON(github.event.inputs.k6-tests-filenames) }}
+        k6-test: ${{ fromJSON(inputs.k6-tests-filenames) }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pnp-build-query-api-v2.yml
+++ b/.github/workflows/pnp-build-query-api-v2.yml
@@ -196,8 +196,9 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
   k6:
-    needs: staging
-    if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
+    if: ${{ inputs.has-k6-tests == true }}
+    needs: build
+    #if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -246,11 +247,11 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
   release:
-    needs: [staging, k6]
+    needs: [build, k6]
     if: |
       always() &&
       github.ref == 'refs/heads/master' &&
-      needs.staging.result == 'success' &&
+      needs.build.result == 'success' &&
       (inputs.has-k6-tests == false || needs.k6.result == 'success')
     runs-on: ubuntu-latest
     steps:
@@ -258,21 +259,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create release
-        uses: extenda/actions/conventional-release@v0
-        id: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Create release
+      #   uses: extenda/actions/conventional-release@v0
+      #   id: release
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: extenda/actions/setup-gcloud@v0
-        with:
-          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+      # - uses: extenda/actions/setup-gcloud@v0
+      #   with:
+      #     service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
 
-      - name: Add tag in GCR
-        run: |
-          gcloud container images add-tag \
-            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
-            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ steps.release.outputs.version }}
+      # - name: Add tag in GCR
+      #   run: |
+      #     gcloud container images add-tag \
+      #       eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
+      #       eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ steps.release.outputs.version }}
       
       - name: Notify Slack if failed
         if: failure()


### PR DESCRIPTION
v2 build workflow for Query API differs from the v1 version in:
- `checkout` github action updated from v2 to v3;
- `setup-dotnet` and `setup-node` github actions updated from v1 to v3;
- you can specify which k6 tests to run instead of hardcoded tests names for v1 and v2 (some of the Query APIs do not have v2 version);
- there is one `release` job instead of two identical with different conditions.