### PR TITLE
feat: Configurable working directory for PNP processors

### DIFF
--- a/.github/workflows/pnp-build-processor-nested.yml
+++ b/.github/workflows/pnp-build-processor-nested.yml
@@ -1,0 +1,329 @@
+name: Merge to master 
+
+on:
+  workflow_call:
+    secrets:
+      GCR_image_name:
+        description: 'A name of the image to be created in GCR'
+        required: true
+      path-to-pom:
+        description: 'Path to the pom file'
+        required: true
+      path-to-dockerfile:
+        description: 'Path to dockerfile which builds the service.'
+        required: true
+      slack-channel:
+        description: 'A slack channel which needs to be notified in case of failure'
+        required: false
+      SECRET_AUTH:
+        required: true
+      GCLOUD_AUTH_STAGING:
+        required: true
+      pact-application-id:
+        required: false
+      pact-webhook-id:
+        required: false
+      working-directory:
+        required: false
+    inputs:
+      path-to-kubernetes-config:
+        description: 'Path to kubernetes config file.'
+        type: string
+        required: true
+      jdk-distribution:
+        description: 'JDK Distribution name'
+        type: string
+        required: false
+        default: 'temurin'
+      java-version:
+        description: 'Java version used in the project'
+        type: string
+        required: false
+        default: '17'
+      use-old-setup-java:
+        description: 'If true uses the java setup step of version 1'
+        type: boolean
+        required: false
+        default: false
+      do-pact-consumer-tests:
+        description: 'If true runs tests defining data contracts'
+        type: boolean
+        required: false
+        default: false
+      do-pact-provider-tests:
+        description: 'If true runs tests verifying implementation against data-contracts'
+        type: boolean
+        required: false
+        default: false
+      is-pact-consumer-can-i-deploy-dry-run:
+        description: 'If true, consumer can-i-deploy step will be executed in dry-run mode'
+        type: boolean
+        required: false
+        default: false
+      is-pact-provider-can-i-deploy-dry-run:
+        description: 'If true, provider can-i-deploy step will be executed in dry-run mode'
+        type: boolean
+        required: false
+        default: false
+      reuse-release:
+        description: 'If true, instead of creating new release reuses the current one. Intended to be used in config-based multi-service deploy scenarios, when multiple service instances created from the same code base.'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      
+      - uses: extenda/actions/gcp-secret-manager@v0
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          secrets: |
+            NEXUS_PASSWORD: nexus-password
+            NEXUS_USERNAME: nexus-username
+
+      - name: Set up JDK
+        if: ${{ inputs.use-old-setup-java == false }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{ inputs.jdk-distribution }}
+          java-version: ${{ inputs.java-version }}
+          cache: maven
+
+      - name: Set up JDK
+        if: ${{ inputs.use-old-setup-java == true }}
+        uses: actions/setup-java@v1
+        with:
+          distribution: ${{ inputs.jdk-distribution }}
+          java-version: ${{ inputs.java-version }}
+
+      - uses: actions/cache@v2
+        if: ${{ inputs.use-old-setup-java == true }}
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Determine version
+        uses: extenda/actions/conventional-version@v0
+        id: semver
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify with Maven
+        uses: extenda/actions/maven@v0
+        with:
+          args: verify -s settings.xml
+          version: ${{ steps.semver.outputs.version }}-SNAPSHOT
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          working-directory: ${{ secrets.working-directory }}
+
+      - name: Analyze with Sonar - nested folder
+        uses: extenda/actions/sonar-scanner@v0
+        with:
+          sonar-host: https://sonarcloud.io
+          maven-args: --file ${{ secrets.path-to-pom }} --settings settings.xml org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          report-path: ${{ secrets.working-directory }}/target/sonar/report-task.txt
+
+      - name: Publish pacts
+        if: ${{ inputs.do-pact-consumer-tests == true }}
+        uses: extenda/actions/pact-publish@v0
+        with:
+          pacts-directory: target/pacts
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+
+      - name: Can i deploy - consumer?
+        if: ${{ inputs.do-pact-consumer-tests == true }}
+        uses: extenda/actions/pact-can-i-deploy@v0
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          application-name: ${{ secrets.pact-application-id }}
+          retry-while-unknown: 15
+          retry-interval: 10
+          dry-run: ${{ inputs.is-pact-consumer-can-i-deploy-dry-run }}
+          env: "staging"
+
+      - name: Can i deploy - provider?
+        if: ${{ inputs.do-pact-provider-tests == true }}
+        uses: extenda/actions/pact-can-i-deploy@v0
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          application-name: ${{ secrets.pact-application-id }}
+          retry-while-unknown: 15
+          retry-interval: 10
+          dry-run: ${{ inputs.is-pact-provider-can-i-deploy-dry-run }}
+          env: "staging"
+
+      - name: Notify Slack if failed
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        uses: extenda/actions/slack-notify@v0
+        with:
+          text: |
+            *Build failed for ${{ github.repository }}: ${{ github.workflow }}* :heavy_exclamation_mark:
+            Build failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{github.job}}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
+          channel: ${{ secrets.slack-channel }}
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+  
+  staging:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      
+      - uses: extenda/actions/gcp-secret-manager@v0
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          secrets: |
+            GITHUB-TOKEN: github-token
+            PACT_BROKER_USERNAME: pact-broker-username
+            PACT_BROKER_PASSWORD: pact-broker-password
+      
+      - name: Determine version
+        uses: extenda/actions/conventional-version@v0
+        id: semver
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up JDK
+        if: ${{ inputs.use-old-setup-java == false }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{ inputs.jdk-distribution }}
+          java-version: ${{ inputs.java-version }}
+          cache: maven
+
+      - name: Set up JDK
+        if: ${{ inputs.use-old-setup-java == true }}
+        uses: actions/setup-java@v1
+        with:
+          distribution: ${{ inputs.jdk-distribution }}
+          java-version: ${{ inputs.java-version }}
+
+      - uses: actions/cache@v2
+        if: ${{ inputs.use-old-setup-java == true }}
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        uses: extenda/actions/maven@v0
+        with:
+          args: install -s settings.xml -DskipTests=false
+          version: ${{ steps.semver.outputs.version }}-SNAPSHOT
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          working-directory: ${{ secrets.working-directory }}
+
+      - name: Setup gcloud
+        uses: extenda/actions/setup-gcloud@v0
+        id: gcloud
+        with:
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+      
+      - name: Authenticate docker
+        run: |
+          gcloud --quiet auth configure-docker
+      
+      - name: Docker build and push
+        run: |
+          IMAGE=eu.gcr.io/extenda/${{ secrets.GCR_image_name }}
+          docker build ./${{ secrets.working-directory }} -f ${{ secrets.path-to-dockerfile }} --build-arg jar_version=${{ steps.semver.outputs.version }} -t $IMAGE:${{ steps.semver.outputs.version }} -t $IMAGE:${{ github.sha }} -t $IMAGE:latest
+          docker push --all-tags $IMAGE
+
+      - name: Attest image
+        uses: extenda/actions/binary-auth-attestation@v0
+        with:
+          image-path: eu.gcr.io/extenda/${{ secrets.GCR_image_name }}
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+      
+      - name: Deploy to Kubernetes (staging)
+        uses: extenda/actions/kubernetes@v0
+        with:
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+          service-definition: ${{ inputs.path-to-kubernetes-config }}
+          image: eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ steps.semver.outputs.version }}
+
+      - name: PACT record deployment to STAGING
+        if: ${{ inputs.do-pact-consumer-tests == true }}
+        uses: extenda/actions/pact-record-deployment@v0
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          application-name: ${{ secrets.pact-application-id }}
+          release-version: ${{ github.sha }}
+          env: "staging"
+            
+      - name: Notify Slack if failed
+        if: failure()
+        uses: extenda/actions/slack-notify@v0
+        with:
+          text: |
+            *Build failed for ${{ github.repository }}: ${{ github.workflow }}* :heavy_exclamation_mark:
+            Build failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{github.job}}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
+          channel: ${{ secrets.slack-channel }}
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+      
+  release:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: staging
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+
+      - name: Create release
+        if: ${{ inputs.reuse-release == false }}
+        uses: extenda/actions/conventional-release@v0
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release (reuse current release mode)
+        if: ${{ inputs.reuse-release == true }}
+        uses: extenda/actions/conventional-version@v0
+        id: release_reuse
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: extenda/actions/setup-gcloud@v0
+        with:
+          service-account-key: ${{ secrets.GCLOUD_AUTH_STAGING }}
+
+      - name: Add tag in GCR
+        run: |
+          gcloud container images add-tag \
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ github.sha }} \
+            eu.gcr.io/extenda/${{ secrets.GCR_image_name }}:${{ env.release_version }}
+        env:
+          release_version: ${{ inputs.reuse-release == false && steps.release.outputs.version || steps.release_reuse.outputs.release-version }}
+
+      - name: Create Pact STAGING release
+        if: ${{ inputs.do-pact-consumer-tests == true && inputs.reuse-release == false }}
+        uses: extenda/actions/pact-tag-version@v0
+        with:
+          service-account-key: ${{ secrets.SECRET_AUTH }}
+          application-name: ${{ secrets.pact-application-id }}
+          release-tag: ${{ steps.release.outputs.release-tag }}
+          env: "staging"
+
+      - name: Notify Slack if failed
+        if: failure()
+        uses: extenda/actions/slack-notify@v0
+        with:
+          text: |
+            *Build failed for ${{ github.repository }}: ${{ github.workflow }}* :heavy_exclamation_mark:
+            Build failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{github.job}}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
+          channel: ${{ secrets.slack-channel }}
+          service-account-key: ${{ secrets.SECRET_AUTH }}


### PR DESCRIPTION
Add new 'pnp-build-processor-nested' - aimed for the multi-processors repositories. I.e. having a single repo with a folder for each of the fully decoupled processors. In this case single repo is used only for logical grouping, simplifying search, etc. Processors are completely atomic, each folder could be considered it's own repo.