### PR TITLE
fix(MCPE-3498): Forbid to start job if all skipped

### DIFF
--- a/.github/workflows/sng-ingestor-shared-workflow.yml
+++ b/.github/workflows/sng-ingestor-shared-workflow.yml
@@ -146,9 +146,10 @@ jobs:
   release:
     if: |
       always() &&
-      (needs.acceptance.result == 'success' || needs.acceptance.result == 'skipped')
+      (needs.acceptance.result == 'success' || needs.acceptance.result == 'skipped') &&
+      (needs.staging.result == 'success')
     runs-on: ubuntu-latest
-    needs: acceptance
+    needs: [staging, acceptance]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -170,9 +171,10 @@ jobs:
     if: |
       always() &&
       (needs.acceptance.result == 'success' || needs.acceptance.result == 'skipped') &&
-      (needs.release.result == 'success' || needs.release.result == 'skipped')
+      (needs.release.result == 'success' || needs.release.result == 'skipped') &&
+      (needs.staging.result == 'success')
     runs-on: ubuntu-latest
-    needs: [release, acceptance]
+    needs: [staging, acceptance, release]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sng-proxy-shared-workflow.yml
+++ b/.github/workflows/sng-proxy-shared-workflow.yml
@@ -131,9 +131,10 @@ jobs:
   release:
     if: |
       always() &&
-      (needs.acceptance.result == 'success' || needs.acceptance.result == 'skipped')
+      (needs.acceptance.result == 'success' || needs.acceptance.result == 'skipped') &&
+      (needs.staging.result == 'success')
     runs-on: ubuntu-latest
-    needs: acceptance
+    needs: [staging, acceptance]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -167,9 +168,10 @@ jobs:
     if: |
       always() &&
       (needs.acceptance.result == 'success' || needs.acceptance.result == 'skipped') &&
-      (needs.release.result == 'success' || needs.release.result == 'skipped')
+      (needs.release.result == 'success' || needs.release.result == 'skipped') &&
+      (needs.staging.result == 'success')
     runs-on: ubuntu-latest
-    needs: [acceptance, release]
+    needs: [staging, acceptance, release]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sng-shared-workflow.yml
+++ b/.github/workflows/sng-shared-workflow.yml
@@ -221,9 +221,10 @@ jobs:
   production:
     if: |
       always() &&
-      (needs.acceptance.result == 'success' || needs.acceptance.result == 'skipped')
+      (needs.acceptance.result == 'success' || needs.acceptance.result == 'skipped') &&
+      (needs.staging.result == 'success')
     runs-on: ubuntu-latest
-    needs: acceptance
+    needs: [acceptance, staging]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Forbid to start jobs when all skipped because of failure in the jobs before acceptance