### PR TITLE
fix: Fix git push in print-topology

### DIFF
--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           if [[ -n $(git status --porcelain) ]]; then
             git add .
-            git pull origin HEAD:${{ github.ref }}
+            git branch -a
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
             git push origin HEAD:${{ github.ref }}
           else

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Fetch
         run: |
-          git fetch origin
-          git reset --hard origin/${{ github.ref }}
+          git fetch origin ${{ github.ref_name }}
+          git reset --hard origin/${{ github.ref_name }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -35,16 +35,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         uses: extenda/actions/setup-git@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fetch
-        run: |
-          git fetch origin ${{ github.ref_name }}
-          git reset --hard origin/${{ github.ref_name }}
+      # - name: Fetch
+      #   run: |
+      #     git fetch origin ${{ github.ref_name }}
+      #     git reset --hard origin/${{ github.ref_name }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -69,7 +69,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
-            git diff HEAD:${{ github.ref }} origin/HEAD:${{ github.ref }}             
+            git pull origin/HEAD:${{ github.ref }}
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -69,7 +69,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
-            git fetch origin HEAD:${{ github.ref }}
+            git log origin ${{ github.ref }}
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -35,18 +35,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Configure Git
         uses: extenda/actions/setup-git@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Fetch
-      #   run: |
-      #     git fetch origin ${{ github.ref_name }}
-      #     git reset --hard origin/${{ github.ref_name }}
+      - name: Sync local with remote repo
+        run: |
+          git fetch origin ${{ github.ref_name }}
+          git reset --hard origin/${{ github.ref_name }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -39,7 +39,11 @@ jobs:
       - name: Configure Git
         uses: extenda/actions/setup-git@v0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }
+
+      - name: Fetch
+        run: |
+            git pull origin HEAD:${{ github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -69,7 +73,6 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
-            git pull origin HEAD:${{ github.ref }} --rebase
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -69,7 +69,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
-            git log origin ${{ github.ref }}
+            git log origin HEAD:${{ github.ref }}
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -69,6 +69,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
+            git pull origin HEAD:${{ github.ref }}
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Fetch
         run: |
           git fetch origin HEAD:${{ github.ref }}
-          git reset --hard origin/${{ github.ref }}
+          git reset --hard origin/HEAD:${{ github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           if [[ -n $(git status --porcelain) ]]; then
             git add .
-            git branch -a
+            git pull origin HEAD:${{ github.ref }} --rebase
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
             git push origin HEAD:${{ github.ref }}
           else

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -69,7 +69,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
-            git log origin/${{ github.ref }}
+            git diff HEAD:${{ github.ref }} origin/HEAD:${{ github.ref }}             
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -68,8 +68,8 @@ jobs:
         run: |
           if [[ -n $(git status --porcelain) ]]; then
             git add .
-            git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
             git pull origin HEAD:${{ github.ref }}
+            git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Fetch
         run: |
-          git fetch origin HEAD:${{ github.ref }}
-          git reset --hard origin/HEAD:${{ github.ref }}
+          git fetch origin
+          git reset --hard origin/${{ github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -68,8 +68,8 @@ jobs:
         run: |
           if [[ -n $(git status --porcelain) ]]; then
             git add .
-            git pull origin HEAD:${{ github.ref }} --rebase
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
+            git pull origin HEAD:${{ github.ref }} --rebase
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Configure Git
         uses: extenda/actions/setup-git@v0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch
         run: |
-            git pull origin HEAD:${{ github.ref }}
+          git pull origin HEAD:${{ github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -69,7 +69,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
-            git log origin HEAD:${{ github.ref }}
+            git log origin/${{ github.ref }}
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -69,7 +69,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
-            git pull origin/HEAD:${{ github.ref }}
+            git pull origin HEAD:${{ github.ref }}
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -43,7 +43,8 @@ jobs:
 
       - name: Fetch
         run: |
-          git pull origin HEAD:${{ github.ref }}
+          git fetch origin HEAD:${{ github.ref }}
+          git reset --hard origin/${{ github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/print-topology.yml
+++ b/.github/workflows/print-topology.yml
@@ -69,7 +69,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git -c user.name="Extenda-DevOps-Bot" -c user.email="devops_team@extenda.se" commit -S -m "Update ${{ inputs.readmeFilePath }}  topology"
-            git pull origin HEAD:${{ github.ref }}
+            git fetch origin HEAD:${{ github.ref }}
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to commit."


### PR DESCRIPTION
print-topology workflow fails when called from multiple jobs within a workflow, with the error below:

error: failed to push some refs to 'https://github.com/extenda/hiiretail-item-category-stream-processor'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. If you want to integrate the remote changes,
hint: use 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.

Solution: sync local branch to the remote one so that each new job will reference the latest commit in remote branch that has been pushed by a previous job