### PR TITLE
build: Force Ubuntu 22.04 for input and query API workflows

### DIFF
--- a/.github/workflows/pnp-api-prod-deploy.yml
+++ b/.github/workflows/pnp-api-prod-deploy.yml
@@ -46,7 +46,7 @@ on:
 jobs:
   prod:
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pnp-input-api-build.yml
+++ b/.github/workflows/pnp-input-api-build.yml
@@ -88,7 +88,7 @@ on:
 
 jobs:
   test-opa-policies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -110,7 +110,7 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
   test-application:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -224,7 +224,7 @@ jobs:
 
   staging:
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test-application
     steps:
       - uses: actions/checkout@v4
@@ -307,7 +307,7 @@ jobs:
 
   acceptance:
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: staging
     steps:
       - uses: actions/checkout@v4
@@ -410,7 +410,7 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: acceptance
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pnp-query-api-build.yml
+++ b/.github/workflows/pnp-query-api-build.yml
@@ -67,7 +67,7 @@ on:
 
 jobs:
   test-opa-policies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,7 +89,7 @@ jobs:
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
   test-application:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -172,7 +172,7 @@ jobs:
   staging:
     needs: test-application
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -244,7 +244,7 @@ jobs:
   acceptance:
     needs: staging
     if: ${{ github.ref == 'refs/heads/master' && inputs.has-k6-tests == true }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         k6-test-file-name: ${{ fromJSON(inputs.k6-tests-file-names) }}
@@ -298,7 +298,7 @@ jobs:
       github.ref == 'refs/heads/master' &&
       needs.staging.result == 'success' &&
       (inputs.has-k6-tests == false || needs.acceptance.result == 'success')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Github changed Ubuntu-latest to Ubuntu-24.04. Changing back to 22.04 as Nuget is not available in 24.04.