### PR TITLE
feat: Remove snapshot postfix from jar versions

### DIFF
--- a/.github/workflows/pnp-build-autopilot-processor-nested.yml
+++ b/.github/workflows/pnp-build-autopilot-processor-nested.yml
@@ -161,7 +161,7 @@ jobs:
         uses: extenda/actions/maven@v0
         with:
           args: verify -s settings.xml
-          version: ${{ steps.semver.outputs.version }}-SNAPSHOT
+          version: ${{ steps.semver.outputs.version }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
           working-directory: ${{ inputs.working-directory || '.' }}
       
@@ -238,7 +238,7 @@ jobs:
         if: ${{ inputs.native-image == true && github.ref == 'refs/heads/master' }}
         with:
           args: verify -Dpackaging=native-image -s settings.xml
-          version: ${{ steps.semver.outputs.version }}-SNAPSHOT
+          version: ${{ steps.semver.outputs.version }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
           working-directory: ${{ inputs.working-directory || '.' }}
 

--- a/.github/workflows/pnp-build-autopilot-processor.yml
+++ b/.github/workflows/pnp-build-autopilot-processor.yml
@@ -153,7 +153,7 @@ jobs:
         uses: extenda/actions/maven@v0
         with:
           args: verify -s settings.xml
-          version: ${{ steps.semver.outputs.version }}-SNAPSHOT
+          version: ${{ steps.semver.outputs.version }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
       - name: Kafka Streams lint - fetch detekt config file
@@ -226,7 +226,7 @@ jobs:
         if: ${{ inputs.native-image == true && github.ref == 'refs/heads/master' }}
         with:
           args: verify -Dpackaging=native-image -s settings.xml
-          version: ${{ steps.semver.outputs.version }}-SNAPSHOT
+          version: ${{ steps.semver.outputs.version }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
           working-directory: ${{ inputs.working-directory || '.' }}
 

--- a/.github/workflows/pnp-processor-build-image.yml
+++ b/.github/workflows/pnp-processor-build-image.yml
@@ -126,7 +126,7 @@ jobs:
         uses: extenda/actions/maven@v0
         with:
           args: verify -s settings.xml
-          version: ${{ steps.semver.outputs.version }}-SNAPSHOT
+          version: ${{ steps.semver.outputs.version }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
 
       - name: Kafka Streams lint - fetch detekt config file
@@ -203,7 +203,7 @@ jobs:
         uses: extenda/actions/maven@v0
         with:
           args: verify -Dpackaging=native-image -s settings.xml
-          version: ${{ steps.semver.outputs.version }}-SNAPSHOT
+          version: ${{ steps.semver.outputs.version }}
           service-account-key: ${{ secrets.SECRET_AUTH }}
     
       - name: Publish pacts


### PR DESCRIPTION
We should not use -SNAPSHOT in a release version because SNAPSHOT means the artifact is mutable and unstable. A release must be immutable, reproducible, and final, while a snapshot can change anytime.

👉 In other words:

Release (1.0.0) = fixed, permanent.

Snapshot (1.0.0-SNAPSHOT) = in-progress, may change on every build.