### PR TITLE
chore: Fix warning about export-default-credentials

### DIFF
--- a/generic/cloud-sql-liquibase/action.yaml
+++ b/generic/cloud-sql-liquibase/action.yaml
@@ -33,7 +33,6 @@ runs:
       id: gcloud
       with:
         service-account-key: ${{ inputs.GCLOUD_AUTH }}
-        export-default-credentials: true
 
     - name: GCloud configure-docker
       shell: bash


### PR DESCRIPTION
Fix this warning:

Input 'export-default-credentials' has been deprecated with message: This input is deprecated. The future default behavior is to always export credentials. This is required for gcloud interoperability with workload identity federation. The post step ensures that exported credentials are cleaned up after the job completes, so there are no security implications to always exporting credentials.

Input 'export-default-credentials' has been deprecated with message: This input is deprecated. The future default behavior is to always export credentials. This is required for gcloud interoperability with workload identity federation. The post step ensures that exported credentials are cleaned up after the job completes, so there are no security implications to always exporting credentials.