### PR TITLE
fix(HII-13198): Fix npm ci error

### DIFF
--- a/composite-actions/nodejs-generic-api/test-unit/README.md
+++ b/composite-actions/nodejs-generic-api/test-unit/README.md
@@ -6,9 +6,13 @@ This is typical action, to run tests in nodejs api application.
 
 ```yaml
 - uses: extenda/shared-workflows/composite-actions/nodejs-generic-api/test-unit@master
+  env:
+    IMAGE_NAME: eu.gcr.io/extenda/att-api
   with:
     GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH_STAGING }}
     SECRET_AUTH: ${{ secrets.SECRET_AUTH }}
+    # Optional override if your image naming differs
+    # vulnerability-scan-image: eu.gcr.io/extenda/att-api:${{ github.sha }}
 ```
 
 ### Requirements
@@ -20,3 +24,10 @@ This is typical action, to run tests in nodejs api application.
 - You must set Node.js version in `.nvmrc` file.
 - You should have a ```npm run check-openapi-schema``` script, to test you openapi schema.
 - You should have a ```npm run ts:check``` script, to check, whether your typescript code is valid.
+- Vulnerability scan image resolution order is:
+  1) ``vulnerability-scan-image``
+  2) ``${IMAGE_NAME}:${GITHUB_SHA}``
+  3) ``eu.gcr.io/extenda/${GITHUB_REPOSITORY#*/}:${GITHUB_SHA}``
+  4) ``eu.gcr.io/extenda/security:${GITHUB_SHA}``
+- The action checks local Docker first, then tries to pull each candidate from registry.
+- If no candidate image can be found, the job fails.

--- a/composite-actions/nodejs-generic-api/test-unit/README.md
+++ b/composite-actions/nodejs-generic-api/test-unit/README.md
@@ -11,8 +11,9 @@ This is typical action, to run tests in nodejs api application.
   with:
     GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH_STAGING }}
     SECRET_AUTH: ${{ secrets.SECRET_AUTH }}
-    # Optional override if your image naming differs
-    # vulnerability-scan-image: eu.gcr.io/extenda/att-api:${{ github.sha }}
+    # Optional
+    # slack-channel: team-ci-alerts
+    # notify-slack-on-fail: true
 ```
 
 ### Requirements
@@ -24,10 +25,7 @@ This is typical action, to run tests in nodejs api application.
 - You must set Node.js version in `.nvmrc` file.
 - You should have a ```npm run check-openapi-schema``` script, to test you openapi schema.
 - You should have a ```npm run ts:check``` script, to check, whether your typescript code is valid.
-- Vulnerability scan image resolution order is:
-  1) ``vulnerability-scan-image``
-  2) ``${IMAGE_NAME}:${GITHUB_SHA}``
-  3) ``eu.gcr.io/extenda/${GITHUB_REPOSITORY#*/}:${GITHUB_SHA}``
-  4) ``eu.gcr.io/extenda/security:${GITHUB_SHA}``
-- The action checks local Docker first, then tries to pull each candidate from registry.
-- If no candidate image can be found, the job fails.
+- Set `IMAGE_NAME` in workflow `env`.
+- The action builds one local image in the test job using `docker build --quiet -t "${IMAGE_NAME}:${GITHUB_SHA}" .`.
+- Trivy scans this locally built image (`${IMAGE_NAME}:${GITHUB_SHA}`).
+- The job fails if `IMAGE_NAME` is missing, `Dockerfile` is missing, or local image build fails.

--- a/composite-actions/nodejs-generic-api/test-unit/README.md
+++ b/composite-actions/nodejs-generic-api/test-unit/README.md
@@ -25,6 +25,8 @@ This is typical action, to run tests in nodejs api application.
 - You must set Node.js version in `.nvmrc` file.
 - You should have a ```npm run check-openapi-schema``` script, to test you openapi schema.
 - You should have a ```npm run ts:check``` script, to check, whether your typescript code is valid.
+- You must commit `.npmrc` in the repository root.
+- You should provide `npm run auth` in `package.json` (the action calls `npm run auth --if-present`).
 - Set `IMAGE_NAME` in workflow `env`.
 - The action builds one local image in the test job using `docker build --quiet -t "${IMAGE_NAME}:${GITHUB_SHA}" .`.
 - Trivy scans this locally built image (`${IMAGE_NAME}:${GITHUB_SHA}`).

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -72,11 +72,14 @@ runs:
       run: |
         cat > .npmrc <<'EOF'
         @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
-        //europe-west1-npm.pkg.dev/extenda/npm/:always-auth=true
         EOF
 
         npx --yes google-artifactregistry-auth --repo-config=.npmrc --credential-config=.npmrc
-        rg "_authToken|_auth=" .npmrc >/dev/null || (echo "No npm credentials written to .npmrc" && exit 1)
+
+        if ! grep -Eq "_authToken|_auth=" .npmrc; then
+          echo "No npm credentials written to .npmrc"
+          exit 1
+        fi
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -116,10 +119,10 @@ runs:
           exit 1
         fi
 
-        rg "_authToken|_auth=" .npmrc >/dev/null || {
+        if ! grep -Eq "_authToken|_auth=" .npmrc; then
           echo ".npmrc does not contain auth token entries required for private npm packages."
           exit 1
-        }
+        fi
 
         export DOCKER_BUILDKIT=1
 

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -93,6 +93,14 @@ runs:
       shell: bash
       run: npm run test:cov
 
+    - name: Vulnerability scan
+      uses: extenda/actions/trivy-scan@v0
+      with:
+        image: eu.gcr.io/extenda/security:${{ github.sha }}
+        service-account-key: ${{ inputs.GCLOUD_AUTH || inputs.SECRET_AUTH }}
+        fail-on-vulnerabilities: true
+        notify-slack-on-vulnerabilities: false
+
     - name: Analyze with SonarCloud
       uses: extenda/actions/sonar-scanner@v0
       with:

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -100,17 +100,41 @@ runs:
       id: scan-image
       shell: bash
       run: |
+        CANDIDATES=()
+
         if [ -n "${{ inputs.vulnerability-scan-image }}" ]; then
-          echo "image=${{ inputs.vulnerability-scan-image }}" >> "$GITHUB_OUTPUT"
-        elif [ -n "${IMAGE_NAME:-}" ]; then
-          echo "image=${IMAGE_NAME}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-        elif [ -n "${GITHUB_REPOSITORY#*/}" ]; then
-          echo "image=eu.gcr.io/extenda/${GITHUB_REPOSITORY#*/}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-        else
-          echo "Unable to resolve vulnerability scan image."
-          echo "Provide inputs.vulnerability-scan-image or set IMAGE_NAME in the caller workflow."
-          exit 1
+          CANDIDATES+=("${{ inputs.vulnerability-scan-image }}")
         fi
+
+        if [ -n "${IMAGE_NAME:-}" ]; then
+          CANDIDATES+=("${IMAGE_NAME}:${GITHUB_SHA}")
+        fi
+
+        if [ -n "${GITHUB_REPOSITORY#*/}" ]; then
+          CANDIDATES+=("eu.gcr.io/extenda/${GITHUB_REPOSITORY#*/}:${GITHUB_SHA}")
+        fi
+
+        # Common shared security image fallback used across projects.
+        CANDIDATES+=("eu.gcr.io/extenda/security:${GITHUB_SHA}")
+
+        for IMAGE in "${CANDIDATES[@]}"; do
+          echo "Trying vulnerability scan image: ${IMAGE}"
+          if docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+            echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if docker pull "${IMAGE}" >/dev/null 2>&1; then
+            echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        done
+
+        echo "Unable to locate a vulnerability scan image for ${GITHUB_SHA}."
+        echo "Tried:"
+        for IMAGE in "${CANDIDATES[@]}"; do
+          echo "- ${IMAGE}"
+        done
+        exit 1
 
     - name: Vulnerability scan
       uses: extenda/actions/trivy-scan@v0

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -74,41 +74,21 @@ runs:
       run: |
         umask 077
 
-        # Workspace npm config with private registry mapping.
-        cat > .npmrc <<'EOF'
+        # Ensure base registry mapping exists in workspace.
+        if [ ! -f ".npmrc" ]; then
+          cat > .npmrc <<'EOF'
         @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
         EOF
-
-        # Candidate npmrc for secret mounting.
-        install -m 600 .npmrc "$RUNNER_TEMP/.npmrc"
-
-        # Service-owned auth hook. Some repos write token to different npmrc paths.
-        NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/.npmrc" npm run auth --if-present
-
-        # Resolve where credentials actually ended up.
-        if grep -Eq "_authToken|_auth=" "$RUNNER_TEMP/.npmrc"; then
-          AUTH_NPMRC="$RUNNER_TEMP/.npmrc"
-        elif [ -f "$HOME/.npmrc" ] && grep -Eq "_authToken|_auth=" "$HOME/.npmrc"; then
-          AUTH_NPMRC="$HOME/.npmrc"
-        elif grep -Eq "_authToken|_auth=" ".npmrc"; then
-          AUTH_NPMRC=".npmrc"
-        else
-          echo "No npm credentials found in RUNNER_TEMP, HOME, or workspace .npmrc"
-          exit 1
+        elif ! grep -q '^@hiiretail:registry=' .npmrc; then
+          echo '@hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/' >> .npmrc
         fi
 
-        echo "NPMRC_SECRET_FILE=$AUTH_NPMRC" >> "$GITHUB_ENV"
+        # Service-owned auth hook (recommended standard).
+        npm run auth --if-present
 
-        # Ensure workspace .npmrc has credentials too (legacy Dockerfiles use COPY . . then npm ci).
-        if [ "$AUTH_NPMRC" != ".npmrc" ]; then
-          cat "$AUTH_NPMRC" > .npmrc
-        fi
-
-        # Extract token for legacy Dockerfile build-arg fallback.
-        TOKEN_LINE="$(grep -E '//europe-west1-npm\.pkg\.dev/extenda/npm/:(_authToken|_auth)=' "$AUTH_NPMRC" | head -n 1 || true)"
-        if [ -n "$TOKEN_LINE" ]; then
-          TOKEN_VALUE="${TOKEN_LINE#*=}"
-          echo "NPM_TOKEN=$TOKEN_VALUE" >> "$GITHUB_ENV"
+        # If auth ended up in HOME npmrc, mirror it to workspace for legacy Dockerfiles.
+        if [ -f "$HOME/.npmrc" ] && grep -Eq "_authToken|_auth=" "$HOME/.npmrc" && ! grep -Eq "_authToken|_auth=" ".npmrc"; then
+          cp "$HOME/.npmrc" .npmrc
         fi
 
     - name: Install dependencies
@@ -151,17 +131,10 @@ runs:
 
         export DOCKER_BUILDKIT=1
 
-        BUILD_ARGS=(--secret id=npmrc,src="${NPMRC_SECRET_FILE}")
-
-        # Legacy fallback for Dockerfiles that do plain `RUN npm ci` (no secret mount).
-        if [ -n "${NPM_TOKEN:-}" ]; then
-          BUILD_ARGS+=(--build-arg "NPM_TOKEN=${NPM_TOKEN}")
-        fi
-
         echo "Building local image for vulnerability scan: $IMAGE"
-        if ! docker build "${BUILD_ARGS[@]}" --quiet -t "$IMAGE" .; then
+        if ! docker build --secret id=npmrc,src=.npmrc --quiet -t "$IMAGE" .; then
           echo "Initial quiet Docker build failed. Retrying with full logs for debugging..."
-          docker build "${BUILD_ARGS[@]}" -t "$IMAGE" .
+          docker build --secret id=npmrc,src=.npmrc -t "$IMAGE" .
           echo "Failed to build image $IMAGE."
           exit 1
         fi

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -70,18 +70,17 @@ runs:
     - name: Run NPM auth script
       shell: bash
       run: |
-        # Restrict permissions for credential files created in this step.
         umask 077
-
-        # Base npm config for this workspace and job-scoped user config.
-        cat > .npmrc <<'EOF'
+        cat > "$RUNNER_TEMP/.npmrc" <<'EOF'
         @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
         EOF
-        install -m 600 .npmrc "$RUNNER_TEMP/.npmrc"
-        echo "NPM_CONFIG_USERCONFIG=$RUNNER_TEMP/.npmrc" >> "$GITHUB_ENV"
 
-        # Service-owned auth hook (if present) should populate npm credentials.
         NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/.npmrc" npm run auth --if-present
+
+        if ! grep -Eq "_authToken|_auth=" "$RUNNER_TEMP/.npmrc"; then
+          echo "No npm credentials written to $RUNNER_TEMP/.npmrc"
+          exit 1
+        fi
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -138,7 +138,7 @@ runs:
       uses: extenda/actions/trivy-scan@v0
       with:
         image: ${{ steps.scan-image.outputs.image }}
-        service-account-key: ${{ inputs.GCLOUD_AUTH || inputs}}
+        service-account-key: ${{ inputs.GCLOUD_AUTH }}
         fail-on-vulnerabilities: true
         notify-slack-on-vulnerabilities: false
 

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -73,18 +73,15 @@ runs:
         # Restrict permissions for credential files created in this step.
         umask 077
 
-        # Runtime .npmrc for this workspace
+        # Base npm config for this workspace and job-scoped user config.
         cat > .npmrc <<'EOF'
         @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
         EOF
+        install -m 600 .npmrc "$RUNNER_TEMP/.npmrc"
+        echo "NPM_CONFIG_USERCONFIG=$RUNNER_TEMP/.npmrc" >> "$GITHUB_ENV"
 
-        # Write token into workspace .npmrc (backward-compatible for repos that COPY . .)
-        npx --yes google-artifactregistry-auth --repo-config=.npmrc --credential-config=.npmrc
-
-        # Use dedicated npm user config without overwriting existing HOME config.
-        NPM_USERCONFIG="$RUNNER_TEMP/.npmrc"
-        install -m 600 .npmrc "$NPM_USERCONFIG"
-        echo "NPM_CONFIG_USERCONFIG=$NPM_USERCONFIG" >> "$GITHUB_ENV"
+        # Service-owned auth hook (if present) should populate npm credentials.
+        NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/.npmrc" npm run auth --if-present
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -127,9 +124,9 @@ runs:
         export DOCKER_BUILDKIT=1
 
         echo "Building local image for vulnerability scan: $IMAGE"
-        if ! docker build --secret id=npmrc,src=.npmrc --quiet -t "$IMAGE" .; then
+        if ! docker build --secret id=npmrc,src="$RUNNER_TEMP/.npmrc" --quiet -t "$IMAGE" .; then
           echo "Initial quiet Docker build failed. Retrying with full logs for debugging..."
-          docker build --secret id=npmrc,src=.npmrc -t "$IMAGE" .
+          docker build --secret id=npmrc,src="$RUNNER_TEMP/.npmrc" -t "$IMAGE" .
           echo "Failed to build image $IMAGE."
           exit 1
         fi
@@ -140,7 +137,7 @@ runs:
       uses: extenda/actions/trivy-scan@v0
       with:
         image: ${{ steps.scan-image.outputs.image }}
-        service-account-key: ${{ inputs.GCLOUD_AUTH }}
+        service-account-key: ${{ inputs.GCLOUD_AUTH || inputs.SECRET_AUTH }}
         fail-on-vulnerabilities: true
         notify-slack-on-vulnerabilities: false
 

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -41,7 +41,7 @@ runs:
     - uses: extenda/actions/setup-gcloud@v0
       id: gcloud
       with:
-        service-account-key: ${{ inputs.GCLOUD_AUTH || inputs.SECRET_AUTH }}
+        service-account-key: ${{ inputs.GCLOUD_AUTH }}
 
     - name: GCloud configure-docker
       shell: bash
@@ -122,7 +122,7 @@ runs:
       uses: extenda/actions/trivy-scan@v0
       with:
         image: ${{ steps.scan-image.outputs.image }}
-        service-account-key: ${{ inputs.GCLOUD_AUTH || inputs.SECRET_AUTH }}
+        service-account-key: ${{ inputs.GCLOUD_AUTH }}
         fail-on-vulnerabilities: true
         notify-slack-on-vulnerabilities: false
 

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -101,7 +101,7 @@ runs:
 
         if [ -z "$IMAGE" ]; then
           echo "Unable to resolve vulnerability scan image tag."
-          echo "Set IMAGE_NAME in the caller workflow."
+          echo "Set IMAGE_NAME in caller workflow."
           exit 1
         fi
 

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -70,7 +70,10 @@ runs:
     - name: Run NPM auth script
       shell: bash
       run: |
-        # Runtime .npmrc for this workspace 
+        # Restrict permissions for credential files created in this step.
+        umask 077
+
+        # Runtime .npmrc for this workspace
         cat > .npmrc <<'EOF'
         @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
         EOF
@@ -79,7 +82,7 @@ runs:
         npx --yes google-artifactregistry-auth --repo-config=.npmrc --credential-config=.npmrc
 
         # Also mirror to HOME for tools that read ~/.npmrc
-        cp .npmrc "$HOME/.npmrc"
+        install -m 600 .npmrc "$HOME/.npmrc"
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -72,31 +72,43 @@ runs:
     - name: Run NPM auth script
       shell: bash
       run: |
-        # Restrict permissions for credential files created in this step.
         umask 077
 
-        # Base npm config for this workspace.
+        # Workspace npm config with private registry mapping.
         cat > .npmrc <<'EOF'
         @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
         EOF
 
-        # Prepare a job-scoped npmrc candidate.
+        # Candidate npmrc for secret mounting.
         install -m 600 .npmrc "$RUNNER_TEMP/.npmrc"
-        echo "NPM_CONFIG_USERCONFIG=$RUNNER_TEMP/.npmrc" >> "$GITHUB_ENV"
 
-        # Service-owned auth hook (if present).
+        # Service-owned auth hook. Some repos write token to different npmrc paths.
         NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/.npmrc" npm run auth --if-present
 
-        # Detect where credentials were actually written.
+        # Resolve where credentials actually ended up.
         if grep -Eq "_authToken|_auth=" "$RUNNER_TEMP/.npmrc"; then
-          echo "NPMRC_SECRET_FILE=$RUNNER_TEMP/.npmrc" >> "$GITHUB_ENV"
+          AUTH_NPMRC="$RUNNER_TEMP/.npmrc"
         elif [ -f "$HOME/.npmrc" ] && grep -Eq "_authToken|_auth=" "$HOME/.npmrc"; then
-          echo "NPMRC_SECRET_FILE=$HOME/.npmrc" >> "$GITHUB_ENV"
-        elif grep -Eq "_authToken|_auth=" .npmrc; then
-          echo "NPMRC_SECRET_FILE=.npmrc" >> "$GITHUB_ENV"
+          AUTH_NPMRC="$HOME/.npmrc"
+        elif grep -Eq "_authToken|_auth=" ".npmrc"; then
+          AUTH_NPMRC=".npmrc"
         else
           echo "No npm credentials found in RUNNER_TEMP, HOME, or workspace .npmrc"
           exit 1
+        fi
+
+        echo "NPMRC_SECRET_FILE=$AUTH_NPMRC" >> "$GITHUB_ENV"
+
+        # Ensure workspace .npmrc has credentials too (legacy Dockerfiles use COPY . . then npm ci).
+        if [ "$AUTH_NPMRC" != ".npmrc" ]; then
+          cat "$AUTH_NPMRC" > .npmrc
+        fi
+
+        # Extract token for legacy Dockerfile build-arg fallback.
+        TOKEN_LINE="$(grep -E '//europe-west1-npm\.pkg\.dev/extenda/npm/:(_authToken|_auth)=' "$AUTH_NPMRC" | head -n 1 || true)"
+        if [ -n "$TOKEN_LINE" ]; then
+          TOKEN_VALUE="${TOKEN_LINE#*=}"
+          echo "NPM_TOKEN=$TOKEN_VALUE" >> "$GITHUB_ENV"
         fi
 
     - name: Install dependencies
@@ -137,17 +149,19 @@ runs:
           exit 1
         fi
 
-        if [ -z "${NPMRC_SECRET_FILE:-}" ] || [ ! -f "${NPMRC_SECRET_FILE}" ]; then
-          echo "NPMRC secret file is missing. Expected: ${NPMRC_SECRET_FILE:-<unset>}"
-          exit 1
-        fi
-
         export DOCKER_BUILDKIT=1
 
+        BUILD_ARGS=(--secret id=npmrc,src="${NPMRC_SECRET_FILE}")
+
+        # Legacy fallback for Dockerfiles that do plain `RUN npm ci` (no secret mount).
+        if [ -n "${NPM_TOKEN:-}" ]; then
+          BUILD_ARGS+=(--build-arg "NPM_TOKEN=${NPM_TOKEN}")
+        fi
+
         echo "Building local image for vulnerability scan: $IMAGE"
-        if ! docker build --secret id=npmrc,src="${NPMRC_SECRET_FILE}" --quiet -t "$IMAGE" .; then
+        if ! docker build "${BUILD_ARGS[@]}" --quiet -t "$IMAGE" .; then
           echo "Initial quiet Docker build failed. Retrying with full logs for debugging..."
-          docker build --secret id=npmrc,src="${NPMRC_SECRET_FILE}" -t "$IMAGE" .
+          docker build "${BUILD_ARGS[@]}" -t "$IMAGE" .
           echo "Failed to build image $IMAGE."
           exit 1
         fi

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -70,8 +70,13 @@ runs:
     - name: Run NPM auth script
       shell: bash
       run: |
-        echo "@hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/" > .npmrc
-        npm run auth -- --credential-config=./.npmrc
+        cat > .npmrc <<'EOF'
+        @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
+        //europe-west1-npm.pkg.dev/extenda/npm/:always-auth=true
+        EOF
+
+        npx --yes google-artifactregistry-auth --repo-config=.npmrc --credential-config=.npmrc
+        rg "_authToken|_auth=" .npmrc >/dev/null || (echo "No npm credentials written to .npmrc" && exit 1)
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -110,6 +115,11 @@ runs:
           echo "No Dockerfile found in repository root."
           exit 1
         fi
+
+        rg "_authToken|_auth=" .npmrc >/dev/null || {
+          echo ".npmrc does not contain auth token entries required for private npm packages."
+          exit 1
+        }
 
         export DOCKER_BUILDKIT=1
 

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -1,5 +1,6 @@
 name: "Run unit tests"
 description: "Run unit tests for the service"
+
 inputs:
   SECRET_AUTH:
     description: "GCP Auth"
@@ -15,6 +16,7 @@ inputs:
     default: false
     type: boolean
     required: false
+
 runs:
   using: "composite"
   steps:
@@ -70,15 +72,30 @@ runs:
     - name: Run NPM auth script
       shell: bash
       run: |
+        # Restrict permissions for credential files created in this step.
         umask 077
-        cat > "$RUNNER_TEMP/.npmrc" <<'EOF'
+
+        # Base npm config for this workspace.
+        cat > .npmrc <<'EOF'
         @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
         EOF
 
+        # Prepare a job-scoped npmrc candidate.
+        install -m 600 .npmrc "$RUNNER_TEMP/.npmrc"
+        echo "NPM_CONFIG_USERCONFIG=$RUNNER_TEMP/.npmrc" >> "$GITHUB_ENV"
+
+        # Service-owned auth hook (if present).
         NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/.npmrc" npm run auth --if-present
 
-        if ! grep -Eq "_authToken|_auth=" "$RUNNER_TEMP/.npmrc"; then
-          echo "No npm credentials written to $RUNNER_TEMP/.npmrc"
+        # Detect where credentials were actually written.
+        if grep -Eq "_authToken|_auth=" "$RUNNER_TEMP/.npmrc"; then
+          echo "NPMRC_SECRET_FILE=$RUNNER_TEMP/.npmrc" >> "$GITHUB_ENV"
+        elif [ -f "$HOME/.npmrc" ] && grep -Eq "_authToken|_auth=" "$HOME/.npmrc"; then
+          echo "NPMRC_SECRET_FILE=$HOME/.npmrc" >> "$GITHUB_ENV"
+        elif grep -Eq "_authToken|_auth=" .npmrc; then
+          echo "NPMRC_SECRET_FILE=.npmrc" >> "$GITHUB_ENV"
+        else
+          echo "No npm credentials found in RUNNER_TEMP, HOME, or workspace .npmrc"
           exit 1
         fi
 
@@ -120,12 +137,17 @@ runs:
           exit 1
         fi
 
+        if [ -z "${NPMRC_SECRET_FILE:-}" ] || [ ! -f "${NPMRC_SECRET_FILE}" ]; then
+          echo "NPMRC secret file is missing. Expected: ${NPMRC_SECRET_FILE:-<unset>}"
+          exit 1
+        fi
+
         export DOCKER_BUILDKIT=1
 
         echo "Building local image for vulnerability scan: $IMAGE"
-        if ! docker build --secret id=npmrc,src="$RUNNER_TEMP/.npmrc" --quiet -t "$IMAGE" .; then
+        if ! docker build --secret id=npmrc,src="${NPMRC_SECRET_FILE}" --quiet -t "$IMAGE" .; then
           echo "Initial quiet Docker build failed. Retrying with full logs for debugging..."
-          docker build --secret id=npmrc,src="$RUNNER_TEMP/.npmrc" -t "$IMAGE" .
+          docker build --secret id=npmrc,src="${NPMRC_SECRET_FILE}" -t "$IMAGE" .
           echo "Failed to build image $IMAGE."
           exit 1
         fi
@@ -153,6 +175,6 @@ runs:
       with:
         text: |
           *Unit test failed for ${{ github.repository }}: ${{ github.workflow }}* :heavy_exclamation_mark:
-          Test failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{github.job}}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
+          Test failed on ${{ github.event_name }} event. Workflow: ${{ github.workflow }}. Job: ${{ github.job }}. Run id: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
         channel: ${{ inputs.slack-channel }}
         service-account-key: ${{ inputs.GCLOUD_AUTH || inputs.SECRET_AUTH }}

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -112,6 +112,8 @@ runs:
 
         echo "Building local image for vulnerability scan: $IMAGE"
         if ! docker build --quiet -t "$IMAGE" .; then
+          echo "Initial quiet Docker build failed. Retrying with full logs for debugging..."
+          docker build -t "$IMAGE" .
           echo "Failed to build image $IMAGE."
           exit 1
         fi

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -96,45 +96,38 @@ runs:
       shell: bash
       run: npm run test:cov
 
-    - name: Resolve vulnerability scan image
+    - name: Build vulnerability scan image
       id: scan-image
       shell: bash
       run: |
-        CANDIDATES=()
-
+        IMAGE=""
         if [ -n "${{ inputs.vulnerability-scan-image }}" ]; then
-          CANDIDATES+=("${{ inputs.vulnerability-scan-image }}")
+          IMAGE="${{ inputs.vulnerability-scan-image }}"
+        elif [ -n "${IMAGE_NAME:-}" ]; then
+          IMAGE="${IMAGE_NAME}:${GITHUB_SHA}"
+        elif [ -n "${GITHUB_REPOSITORY#*/}" ]; then
+          IMAGE="eu.gcr.io/extenda/${GITHUB_REPOSITORY#*/}:${GITHUB_SHA}"
         fi
 
-        if [ -n "${IMAGE_NAME:-}" ]; then
-          CANDIDATES+=("${IMAGE_NAME}:${GITHUB_SHA}")
+        if [ -z "${IMAGE}" ]; then
+          echo "Unable to resolve vulnerability scan image tag."
+          echo "Provide inputs.vulnerability-scan-image or set IMAGE_NAME in the caller workflow."
+          exit 1
         fi
 
-        if [ -n "${GITHUB_REPOSITORY#*/}" ]; then
-          CANDIDATES+=("eu.gcr.io/extenda/${GITHUB_REPOSITORY#*/}:${GITHUB_SHA}")
+        if [ ! -f Dockerfile ]; then
+          echo "No Dockerfile found in repository root."
+          exit 1
         fi
 
-        # Common shared security image fallback used across projects.
-        CANDIDATES+=("eu.gcr.io/extenda/security:${GITHUB_SHA}")
+        echo "Building local image for vulnerability scan: ${IMAGE}"
+        docker build -t "${IMAGE}" .
+        if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+          echo "Failed to build image ${IMAGE}."
+          exit 1
+        fi
 
-        for IMAGE in "${CANDIDATES[@]}"; do
-          echo "Trying vulnerability scan image: ${IMAGE}"
-          if docker image inspect "${IMAGE}" >/dev/null 2>&1; then
-            echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if docker pull "${IMAGE}" >/dev/null 2>&1; then
-            echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-        done
-
-        echo "Unable to locate a vulnerability scan image for ${GITHUB_SHA}."
-        echo "Tried:"
-        for IMAGE in "${CANDIDATES[@]}"; do
-          echo "- ${IMAGE}"
-        done
-        exit 1
+        echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
 
     - name: Vulnerability scan
       uses: extenda/actions/trivy-scan@v0

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -7,9 +7,6 @@ inputs:
   GCLOUD_AUTH:
     description: "GCP Auth (staging)"
     required: false
-  vulnerability-scan-image:
-    description: "Container image to scan for vulnerabilities"
-    required: false
   slack-channel:
     description: Name of the channel to notify failing action
     required: false
@@ -59,7 +56,7 @@ runs:
       env:
         cache-name: cache-sonar-binary
       with:
-        path: /home/runner/.sonar/native-sonar-scanner
+        path: /home/runner/.sonar/cache
         key: ${{ runner.os }}-cache-sonar-binary
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}
@@ -100,34 +97,26 @@ runs:
       id: scan-image
       shell: bash
       run: |
-        IMAGE=""
-        if [ -n "${{ inputs.vulnerability-scan-image }}" ]; then
-          IMAGE="${{ inputs.vulnerability-scan-image }}"
-        elif [ -n "${IMAGE_NAME:-}" ]; then
-          IMAGE="${IMAGE_NAME}:${GITHUB_SHA}"
-        elif [ -n "${GITHUB_REPOSITORY#*/}" ]; then
-          IMAGE="eu.gcr.io/extenda/${GITHUB_REPOSITORY#*/}:${GITHUB_SHA}"
-        fi
+        IMAGE="${IMAGE_NAME:+${IMAGE_NAME}:${GITHUB_SHA}}"
 
-        if [ -z "${IMAGE}" ]; then
+        if [ -z "$IMAGE" ]; then
           echo "Unable to resolve vulnerability scan image tag."
-          echo "Provide inputs.vulnerability-scan-image or set IMAGE_NAME in the caller workflow."
+          echo "Set IMAGE_NAME in the caller workflow."
           exit 1
         fi
 
-        if [ ! -f Dockerfile ]; then
+        if [ ! -f "Dockerfile" ]; then
           echo "No Dockerfile found in repository root."
           exit 1
         fi
 
-        echo "Building local image for vulnerability scan: ${IMAGE}"
-        docker build -t "${IMAGE}" .
-        if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
-          echo "Failed to build image ${IMAGE}."
+        echo "Building local image for vulnerability scan: $IMAGE"
+        if ! docker build --quiet -t "$IMAGE" .; then
+          echo "Failed to build image $IMAGE."
           exit 1
         fi
 
-        echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+        echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
 
     - name: Vulnerability scan
       uses: extenda/actions/trivy-scan@v0

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -70,14 +70,20 @@ runs:
     - name: Run NPM auth script
       shell: bash
       run: |
+        # Repo .npmrc: registry mapping only
         cat > .npmrc <<'EOF'
         @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
         EOF
 
-        npx --yes google-artifactregistry-auth --repo-config=.npmrc --credential-config=.npmrc
+        # Write credentials to HOME npmrc (reliable location in CI)
+        npx --yes google-artifactregistry-auth --repo-config=.npmrc --credential-config="$HOME/.npmrc"
 
-        if ! grep -Eq "_authToken|_auth=" .npmrc; then
-          echo "No npm credentials written to .npmrc"
+        if grep -Eq "_authToken|_auth=" "$HOME/.npmrc"; then
+          echo "NPMRC_SECRET_FILE=$HOME/.npmrc" >> "$GITHUB_ENV"
+        elif grep -Eq "_authToken|_auth=" .npmrc; then
+          echo "NPMRC_SECRET_FILE=.npmrc" >> "$GITHUB_ENV"
+        else
+          echo "No npm credentials written to either \$HOME/.npmrc or ./.npmrc"
           exit 1
         fi
 
@@ -119,25 +125,17 @@ runs:
           exit 1
         fi
 
-        if ! grep -Eq "_authToken|_auth=" .npmrc; then
-          echo ".npmrc does not contain auth token entries required for private npm packages."
+        if [ -z "${NPMRC_SECRET_FILE:-}" ] || [ ! -f "${NPMRC_SECRET_FILE}" ]; then
+          echo "NPMRC secret file is missing. Expected file: ${NPMRC_SECRET_FILE:-<unset>}"
           exit 1
         fi
 
         export DOCKER_BUILDKIT=1
 
-        BUILD_ARGS=()
-        if [ -f ".npmrc" ]; then
-          echo "Detected .npmrc, mounting as BuildKit secret."
-          BUILD_ARGS+=(--secret id=npmrc,src=.npmrc)
-        else
-          echo "No .npmrc found, building without npm secret."
-        fi
-
         echo "Building local image for vulnerability scan: $IMAGE"
-        if ! docker build "${BUILD_ARGS[@]}" --quiet -t "$IMAGE" .; then
+        if ! docker build --secret id=npmrc,src="${NPMRC_SECRET_FILE}" --quiet -t "$IMAGE" .; then
           echo "Initial quiet Docker build failed. Retrying with full logs for debugging..."
-          docker build "${BUILD_ARGS[@]}" -t "$IMAGE" .
+          docker build --secret id=npmrc,src="${NPMRC_SECRET_FILE}" -t "$IMAGE" .
           echo "Failed to build image $IMAGE."
           exit 1
         fi

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -70,22 +70,16 @@ runs:
     - name: Run NPM auth script
       shell: bash
       run: |
-        # Repo .npmrc: registry mapping only
+        # Runtime .npmrc for this workspace (not committed)
         cat > .npmrc <<'EOF'
         @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
         EOF
 
-        # Write credentials to HOME npmrc (reliable location in CI)
-        npx --yes google-artifactregistry-auth --repo-config=.npmrc --credential-config="$HOME/.npmrc"
+        # Write token into workspace .npmrc (backward-compatible for repos that COPY . .)
+        npx --yes google-artifactregistry-auth --repo-config=.npmrc --credential-config=.npmrc
 
-        if grep -Eq "_authToken|_auth=" "$HOME/.npmrc"; then
-          echo "NPMRC_SECRET_FILE=$HOME/.npmrc" >> "$GITHUB_ENV"
-        elif grep -Eq "_authToken|_auth=" .npmrc; then
-          echo "NPMRC_SECRET_FILE=.npmrc" >> "$GITHUB_ENV"
-        else
-          echo "No npm credentials written to either \$HOME/.npmrc or ./.npmrc"
-          exit 1
-        fi
+        # Also mirror to HOME for tools that read ~/.npmrc
+        cp .npmrc "$HOME/.npmrc"
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -125,17 +119,12 @@ runs:
           exit 1
         fi
 
-        if [ -z "${NPMRC_SECRET_FILE:-}" ] || [ ! -f "${NPMRC_SECRET_FILE}" ]; then
-          echo "NPMRC secret file is missing. Expected file: ${NPMRC_SECRET_FILE:-<unset>}"
-          exit 1
-        fi
-
         export DOCKER_BUILDKIT=1
 
         echo "Building local image for vulnerability scan: $IMAGE"
-        if ! docker build --secret id=npmrc,src="${NPMRC_SECRET_FILE}" --quiet -t "$IMAGE" .; then
+        if ! docker build --secret id=npmrc,src=.npmrc --quiet -t "$IMAGE" .; then
           echo "Initial quiet Docker build failed. Retrying with full logs for debugging..."
-          docker build --secret id=npmrc,src="${NPMRC_SECRET_FILE}" -t "$IMAGE" .
+          docker build --secret id=npmrc,src=.npmrc -t "$IMAGE" .
           echo "Failed to build image $IMAGE."
           exit 1
         fi

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -70,7 +70,7 @@ runs:
     - name: Run NPM auth script
       shell: bash
       run: |
-        # Runtime .npmrc for this workspace (not committed)
+        # Runtime .npmrc for this workspace 
         cat > .npmrc <<'EOF'
         @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
         EOF

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -10,7 +10,6 @@ inputs:
   vulnerability-scan-image:
     description: "Container image to scan for vulnerabilities"
     required: false
-    default: eu.gcr.io/extenda/security:${{ github.sha }}
   slack-channel:
     description: Name of the channel to notify failing action
     required: false
@@ -45,7 +44,7 @@ runs:
     - uses: extenda/actions/setup-gcloud@v0
       id: gcloud
       with:
-        service-account-key: ${{ inputs.GCLOUD_AUTH }}
+        service-account-key: ${{ inputs.GCLOUD_AUTH || inputs.SECRET_AUTH }}
 
     - name: GCloud configure-docker
       shell: bash
@@ -97,10 +96,26 @@ runs:
       shell: bash
       run: npm run test:cov
 
+    - name: Resolve vulnerability scan image
+      id: scan-image
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.vulnerability-scan-image }}" ]; then
+          echo "image=${{ inputs.vulnerability-scan-image }}" >> "$GITHUB_OUTPUT"
+        elif [ -n "${IMAGE_NAME:-}" ]; then
+          echo "image=${IMAGE_NAME}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+        elif [ -n "${GITHUB_REPOSITORY#*/}" ]; then
+          echo "image=eu.gcr.io/extenda/${GITHUB_REPOSITORY#*/}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+        else
+          echo "Unable to resolve vulnerability scan image."
+          echo "Provide inputs.vulnerability-scan-image or set IMAGE_NAME in the caller workflow."
+          exit 1
+        fi
+
     - name: Vulnerability scan
       uses: extenda/actions/trivy-scan@v0
       with:
-        image: ${{ inputs.vulnerability-scan-image }}
+        image: ${{ steps.scan-image.outputs.image }}
         service-account-key: ${{ inputs.GCLOUD_AUTH || inputs.SECRET_AUTH }}
         fail-on-vulnerabilities: true
         notify-slack-on-vulnerabilities: false

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -44,7 +44,7 @@ runs:
     - uses: extenda/actions/setup-gcloud@v0
       id: gcloud
       with:
-        service-account-key: ${{ inputs.GCLOUD_AUTH }}
+        service-account-key: ${{ inputs.GCLOUD_AUTH || inputs.SECRET_AUTH }}
 
     - name: GCloud configure-docker
       shell: bash
@@ -74,22 +74,15 @@ runs:
       run: |
         umask 077
 
-        # Ensure base registry mapping exists in workspace.
+        # Use repository-owned npm config only.
         if [ ! -f ".npmrc" ]; then
-          cat > .npmrc <<'EOF'
-        @hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/
-        EOF
-        elif ! grep -q '^@hiiretail:registry=' .npmrc; then
-          echo '@hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/' >> .npmrc
+          echo "Missing .npmrc in repository root."
+          echo "Please commit .npmrc and provide npm auth script in package.json."
+          exit 1
         fi
 
         # Service-owned auth hook (recommended standard).
         npm run auth --if-present
-
-        # If auth ended up in HOME npmrc, mirror it to workspace for legacy Dockerfiles.
-        if [ -f "$HOME/.npmrc" ] && grep -Eq "_authToken|_auth=" "$HOME/.npmrc" && ! grep -Eq "_authToken|_auth=" ".npmrc"; then
-          cp "$HOME/.npmrc" .npmrc
-        fi
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -145,7 +138,7 @@ runs:
       uses: extenda/actions/trivy-scan@v0
       with:
         image: ${{ steps.scan-image.outputs.image }}
-        service-account-key: ${{ inputs.GCLOUD_AUTH }}
+        service-account-key: ${{ inputs.GCLOUD_AUTH || inputs}}
         fail-on-vulnerabilities: true
         notify-slack-on-vulnerabilities: false
 

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -7,6 +7,10 @@ inputs:
   GCLOUD_AUTH:
     description: "GCP Auth (staging)"
     required: false
+  vulnerability-scan-image:
+    description: "Container image to scan for vulnerabilities"
+    required: false
+    default: eu.gcr.io/extenda/security:${{ github.sha }}
   slack-channel:
     description: Name of the channel to notify failing action
     required: false
@@ -96,7 +100,7 @@ runs:
     - name: Vulnerability scan
       uses: extenda/actions/trivy-scan@v0
       with:
-        image: eu.gcr.io/extenda/security:${{ github.sha }}
+        image: ${{ inputs.vulnerability-scan-image }}
         service-account-key: ${{ inputs.GCLOUD_AUTH || inputs.SECRET_AUTH }}
         fail-on-vulnerabilities: true
         notify-slack-on-vulnerabilities: false

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -81,8 +81,10 @@ runs:
         # Write token into workspace .npmrc (backward-compatible for repos that COPY . .)
         npx --yes google-artifactregistry-auth --repo-config=.npmrc --credential-config=.npmrc
 
-        # Also mirror to HOME for tools that read ~/.npmrc
-        install -m 600 .npmrc "$HOME/.npmrc"
+        # Use dedicated npm user config without overwriting existing HOME config.
+        NPM_USERCONFIG="$RUNNER_TEMP/.npmrc"
+        install -m 600 .npmrc "$NPM_USERCONFIG"
+        echo "NPM_CONFIG_USERCONFIG=$NPM_USERCONFIG" >> "$GITHUB_ENV"
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -137,7 +137,7 @@ runs:
       uses: extenda/actions/trivy-scan@v0
       with:
         image: ${{ steps.scan-image.outputs.image }}
-        service-account-key: ${{ inputs.GCLOUD_AUTH || inputs.SECRET_AUTH }}
+        service-account-key: ${{ inputs.GCLOUD_AUTH }}
         fail-on-vulnerabilities: true
         notify-slack-on-vulnerabilities: false
 

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -34,6 +34,7 @@ runs:
     - name: Copy test .env files
       shell: bash
       run: cp test/example.env .env
+
     - name: Copy .env files
       shell: bash
       run: find . -type f -name '*example.env' -execdir mv {} .env ';'
@@ -70,7 +71,7 @@ runs:
       shell: bash
       run: |
         echo "@hiiretail:registry=https://europe-west1-npm.pkg.dev/extenda/npm/" > .npmrc
-        npm run auth  -- --credential-config=./.npmrc
+        npm run auth -- --credential-config=./.npmrc
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -110,10 +111,20 @@ runs:
           exit 1
         fi
 
+        export DOCKER_BUILDKIT=1
+
+        BUILD_ARGS=()
+        if [ -f ".npmrc" ]; then
+          echo "Detected .npmrc, mounting as BuildKit secret."
+          BUILD_ARGS+=(--secret id=npmrc,src=.npmrc)
+        else
+          echo "No .npmrc found, building without npm secret."
+        fi
+
         echo "Building local image for vulnerability scan: $IMAGE"
-        if ! docker build --quiet -t "$IMAGE" .; then
+        if ! docker build "${BUILD_ARGS[@]}" --quiet -t "$IMAGE" .; then
           echo "Initial quiet Docker build failed. Retrying with full logs for debugging..."
-          docker build -t "$IMAGE" .
+          docker build "${BUILD_ARGS[@]}" -t "$IMAGE" .
           echo "Failed to build image $IMAGE."
           exit 1
         fi


### PR DESCRIPTION
## Summary

Updated the shared `test-unit` composite action to make npm authentication reliable across services during vulnerability-scan image builds.

## What Changed

- Standardized CI npm auth by creating a runtime `.npmrc` with the `@hiiretail` Artifact Registry scope.
- Ran `google-artifactregistry-auth` against that runtime `.npmrc` so credentials are written where the workflow expects them.
- Mirrored npm credentials to `$HOME/.npmrc` for compatibility with tools/environments that read home-level npm config.
- Updated Docker build to always pass npm credentials via BuildKit secret:
  - `--secret id=npmrc,src=.npmrc`
- Kept existing lint/typecheck/test/scan flow unchanged.

## Why

Some services passed unit tests but failed in Docker image build (`npm ci` inside Docker) with `E401` due to auth context mismatch between runner and container.

Because repositories use different Dockerfile patterns (`COPY . .` vs BuildKit secret consumption), the action needed a backward-compatible auth strategy that works for both.

## Outcome

This change improves cross-repo compatibility by supporting:

- services relying on workspace `.npmrc` behavior, and
- services consuming npm auth via Docker BuildKit secrets.

It reduces CI breakage without changing the expected pipeline stages or behavior.