### PR TITLE
feat: Use node-version input in frontend-generic composite actions

### DIFF
--- a/composite-actions/frontend-generic/prod-cloud-deploy/action.yaml
+++ b/composite-actions/frontend-generic/prod-cloud-deploy/action.yaml
@@ -92,13 +92,8 @@ runs:
         service-account-key: ${{ inputs.GCLOUD_AUTH_STAGING }}
 
     - uses: actions/setup-node@v4
-      if: inputs.node-version-file == ''
       with:
-        node-version: ${{ inputs.node-version }}
-
-    - uses: actions/setup-node@v4
-      if: inputs.node-version-file != ''
-      with:
+        node-version: ${{ inputs.node-version-file == '' && inputs.node-version || '' }}
         node-version-file: ${{ inputs.node-version-file }}
 
     - name: Auth to Nexus npm registry

--- a/composite-actions/frontend-generic/prod-cloud-deploy/action.yaml
+++ b/composite-actions/frontend-generic/prod-cloud-deploy/action.yaml
@@ -92,8 +92,13 @@ runs:
         service-account-key: ${{ inputs.GCLOUD_AUTH_STAGING }}
 
     - uses: actions/setup-node@v4
+      if: inputs.node-version-file == ''
       with:
-        node-version: ${{ inputs.node-version-file == '' && inputs.node-version || '' }}
+        node-version: ${{ inputs.node-version }}
+
+    - uses: actions/setup-node@v4
+      if: inputs.node-version-file != ''
+      with:
         node-version-file: ${{ inputs.node-version-file }}
 
     - name: Auth to Nexus npm registry

--- a/composite-actions/frontend-generic/prod-cloud-deploy/action.yaml
+++ b/composite-actions/frontend-generic/prod-cloud-deploy/action.yaml
@@ -35,6 +35,10 @@ inputs:
     description: 'Node.js version to use'
     required: false
     default: '20'
+  node-version-file:
+    description: 'File containing the Node.js version to use'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -88,8 +92,14 @@ runs:
         service-account-key: ${{ inputs.GCLOUD_AUTH_STAGING }}
 
     - uses: actions/setup-node@v4
+      if: inputs.node-version-file == ''
       with:
         node-version: ${{ inputs.node-version }}
+
+    - uses: actions/setup-node@v4
+      if: inputs.node-version-file != ''
+      with:
+        node-version-file: ${{ inputs.node-version-file }}
 
     - name: Auth to Nexus npm registry
       uses: extenda/actions/nexus-auth-npm@v0

--- a/composite-actions/frontend-generic/prod-cloud-deploy/action.yaml
+++ b/composite-actions/frontend-generic/prod-cloud-deploy/action.yaml
@@ -31,6 +31,10 @@ inputs:
     description: 'Use GAR auth workflow (true/false)'
     required: false
     default: 'false'
+  node-version:
+    description: 'Node.js version to use'
+    required: false
+    default: '20'
 
 runs:
   using: 'composite'
@@ -85,7 +89,7 @@ runs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: ${{ inputs.node-version }}
 
     - name: Auth to Nexus npm registry
       uses: extenda/actions/nexus-auth-npm@v0

--- a/composite-actions/frontend-generic/prod-cloud-deploy/action.yaml
+++ b/composite-actions/frontend-generic/prod-cloud-deploy/action.yaml
@@ -82,13 +82,13 @@ runs:
       shell: bash
       run: |
         gcloud --quiet auth configure-docker
-        docker build --provenance=false --build-arg LD_CLIENT_ID=${{ env.LD_CLIENT_ID }} -t ${{ inputs.image }}:${{ github.sha }} .
-        docker push ${{ inputs.image }}:${{ github.sha }}
+        docker build --provenance=false --build-arg LD_CLIENT_ID=${{ env.LD_CLIENT_ID }} -t ${{ inputs.IMAGE }}:${{ github.sha }} .
+        docker push ${{ inputs.IMAGE }}:${{ github.sha }}
 
     - name: Attest image
       uses: extenda/actions/binary-auth-attestation@v0
       with:
-        image-path: ${{ inputs.image }}:${{ github.sha }}
+        image-path: ${{ inputs.IMAGE }}:${{ github.sha }}
         service-account-key: ${{ inputs.GCLOUD_AUTH_STAGING }}
 
     - uses: actions/setup-node@v4
@@ -142,8 +142,8 @@ runs:
       shell: bash
       run: |
         gcloud container images add-tag \
-            ${{ inputs.image }}:${{ github.sha }} \
-            ${{ inputs.image }}:${{ steps.release.outputs.release-tag }}
+            ${{ inputs.IMAGE }}:${{ github.sha }} \
+            ${{ inputs.IMAGE }}:${{ steps.release.outputs.release-tag }}
 
     - uses: extenda/actions/conventional-version@v0
       id: semver
@@ -160,4 +160,4 @@ runs:
         secrets-account-key: ${{ inputs.SECRET_AUTH }}
         service-account-key: ${{ inputs.GCLOUD_AUTH_PROD }}
         update-dns: always
-        image: ${{ inputs.image }}:${{ steps.semver.outputs.release-tag }}
+        image: ${{ inputs.IMAGE }}:${{ steps.semver.outputs.release-tag }}

--- a/composite-actions/frontend-generic/prod-deploy/action.yaml
+++ b/composite-actions/frontend-generic/prod-deploy/action.yaml
@@ -64,13 +64,8 @@ runs:
         service-account-key: ${{ inputs.GCLOUD_AUTH_STAGING }}
 
     - uses: actions/setup-node@v4
-      if: inputs.node-version-file == ''
       with:
-        node-version: ${{ inputs.node-version }}
-
-    - uses: actions/setup-node@v4
-      if: inputs.node-version-file != ''
-      with:
+        node-version: ${{ inputs.node-version-file == '' && inputs.node-version || '' }}
         node-version-file: ${{ inputs.node-version-file }}
 
     - name: Create release

--- a/composite-actions/frontend-generic/prod-deploy/action.yaml
+++ b/composite-actions/frontend-generic/prod-deploy/action.yaml
@@ -64,8 +64,13 @@ runs:
         service-account-key: ${{ inputs.GCLOUD_AUTH_STAGING }}
 
     - uses: actions/setup-node@v4
+      if: inputs.node-version-file == ''
       with:
-        node-version: ${{ inputs.node-version-file == '' && inputs.node-version || '' }}
+        node-version: ${{ inputs.node-version }}
+
+    - uses: actions/setup-node@v4
+      if: inputs.node-version-file != ''
+      with:
         node-version-file: ${{ inputs.node-version-file }}
 
     - name: Create release

--- a/composite-actions/frontend-generic/prod-deploy/action.yaml
+++ b/composite-actions/frontend-generic/prod-deploy/action.yaml
@@ -18,6 +18,10 @@ inputs:
   IMAGE:
     description: "Image name for the service (without tag)"
     required: true
+  node-version:
+    description: 'Node.js version to use'
+    required: false
+    default: '20'
 
 runs:
   using: "composite"
@@ -57,7 +61,7 @@ runs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: ${{ inputs.node-version }}
 
     - name: Create release
       uses: extenda/actions/conventional-release@v0

--- a/composite-actions/frontend-generic/prod-deploy/action.yaml
+++ b/composite-actions/frontend-generic/prod-deploy/action.yaml
@@ -22,6 +22,10 @@ inputs:
     description: 'Node.js version to use'
     required: false
     default: '20'
+  node-version-file:
+    description: 'File containing the Node.js version to use'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -60,8 +64,14 @@ runs:
         service-account-key: ${{ inputs.GCLOUD_AUTH_STAGING }}
 
     - uses: actions/setup-node@v4
+      if: inputs.node-version-file == ''
       with:
         node-version: ${{ inputs.node-version }}
+
+    - uses: actions/setup-node@v4
+      if: inputs.node-version-file != ''
+      with:
+        node-version-file: ${{ inputs.node-version-file }}
 
     - name: Create release
       uses: extenda/actions/conventional-release@v0

--- a/composite-actions/frontend-generic/prod-deploy/action.yaml
+++ b/composite-actions/frontend-generic/prod-deploy/action.yaml
@@ -54,13 +54,13 @@ runs:
       shell: bash
       run: |
         gcloud --quiet auth configure-docker
-        docker build --build-arg LD_CLIENT_ID=${{ env.LD_CLIENT_ID }} -t ${{ inputs.image }}:${{ github.sha }} .
-        docker push ${{ inputs.image }}:${{ github.sha }}
+        docker build --build-arg LD_CLIENT_ID=${{ env.LD_CLIENT_ID }} -t ${{ inputs.IMAGE }}:${{ github.sha }} .
+        docker push ${{ inputs.IMAGE }}:${{ github.sha }}
 
     - name: Attest image
       uses: extenda/actions/binary-auth-attestation@v0
       with:
-        image-path: ${{ inputs.image }}:${{ github.sha }}
+        image-path: ${{ inputs.IMAGE }}:${{ github.sha }}
         service-account-key: ${{ inputs.GCLOUD_AUTH_STAGING }}
 
     - uses: actions/setup-node@v4
@@ -87,8 +87,8 @@ runs:
       shell: bash
       run: |
         gcloud container images add-tag \
-            ${{ inputs.image }}:${{ github.sha }} \
-            ${{ inputs.image }}:${{ steps.release.outputs.release-tag }}
+            ${{ inputs.IMAGE }}:${{ github.sha }} \
+            ${{ inputs.IMAGE }}:${{ steps.release.outputs.release-tag }}
 
     - name: Auth to Nexus npm registry
       uses: extenda/actions/nexus-auth-npm@v0
@@ -107,4 +107,4 @@ runs:
       uses: extenda/actions/cloud-run@v0
       with:
         service-account-key: ${{ inputs.GCLOUD_AUTH_PROD }}
-        image: ${{ inputs.image }}:${{ steps.semver.outputs.release-tag }}
+        image: ${{ inputs.IMAGE }}:${{ steps.semver.outputs.release-tag }}

--- a/composite-actions/frontend-generic/test/action.yaml
+++ b/composite-actions/frontend-generic/test/action.yaml
@@ -11,6 +11,10 @@ inputs:
     description: 'Use GAR auth workflow (true/false)'
     required: false
     default: 'false'
+  node-version:
+    description: 'Node.js version to use'
+    required: false
+    default: '20'
 runs:
   using: 'composite'
   steps:
@@ -66,7 +70,7 @@ runs:
     - name: Install Node
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: ${{ inputs.node-version }}
 
     - name: Auth to Nexus npm registry
       if: inputs.GAR_WORKFLOW != 'true'

--- a/composite-actions/frontend-generic/test/action.yaml
+++ b/composite-actions/frontend-generic/test/action.yaml
@@ -73,14 +73,8 @@ runs:
 
     - name: Install Node
       uses: actions/setup-node@v4
-      if: inputs.node-version-file == ''
       with:
-        node-version: ${{ inputs.node-version }}
-
-    - name: Install Node from version file
-      uses: actions/setup-node@v4
-      if: inputs.node-version-file != ''
-      with:
+        node-version: ${{ inputs.node-version-file == '' && inputs.node-version || '' }}
         node-version-file: ${{ inputs.node-version-file }}
 
     - name: Auth to Nexus npm registry

--- a/composite-actions/frontend-generic/test/action.yaml
+++ b/composite-actions/frontend-generic/test/action.yaml
@@ -73,8 +73,14 @@ runs:
 
     - name: Install Node
       uses: actions/setup-node@v4
+      if: inputs.node-version-file == ''
       with:
-        node-version: ${{ inputs.node-version-file == '' && inputs.node-version || '' }}
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install Node from version file
+      uses: actions/setup-node@v4
+      if: inputs.node-version-file != ''
+      with:
         node-version-file: ${{ inputs.node-version-file }}
 
     - name: Auth to Nexus npm registry

--- a/composite-actions/frontend-generic/test/action.yaml
+++ b/composite-actions/frontend-generic/test/action.yaml
@@ -15,6 +15,10 @@ inputs:
     description: 'Node.js version to use'
     required: false
     default: '20'
+  node-version-file:
+    description: 'File containing the Node.js version to use'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -69,8 +73,15 @@ runs:
 
     - name: Install Node
       uses: actions/setup-node@v4
+      if: inputs.node-version-file == ''
       with:
         node-version: ${{ inputs.node-version }}
+
+    - name: Install Node from version file
+      uses: actions/setup-node@v4
+      if: inputs.node-version-file != ''
+      with:
+        node-version-file: ${{ inputs.node-version-file }}
 
     - name: Auth to Nexus npm registry
       if: inputs.GAR_WORKFLOW != 'true'

--- a/composite-actions/frontend-generic/upload-source-maps/action.yaml
+++ b/composite-actions/frontend-generic/upload-source-maps/action.yaml
@@ -51,8 +51,14 @@ runs:
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
+      if: inputs.node-version-file == ''
       with:
-        node-version: ${{ inputs.node-version-file == '' && inputs.node-version || '' }}
+        node-version: ${{ inputs.node-version }}
+
+    - name: Setup Node.js from version file
+      uses: actions/setup-node@v3
+      if: inputs.node-version-file != ''
+      with:
         node-version-file: ${{ inputs.node-version-file }}
 
     - name: Auth to Nexus npm registry

--- a/composite-actions/frontend-generic/upload-source-maps/action.yaml
+++ b/composite-actions/frontend-generic/upload-source-maps/action.yaml
@@ -28,6 +28,10 @@ inputs:
     description: 'Node.js version to use'
     required: false
     default: '20'
+  node-version-file:
+    description: 'File containing the Node.js version to use'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -47,8 +51,15 @@ runs:
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
+      if: inputs.node-version-file == ''
       with:
         node-version: ${{ inputs.node-version }}
+
+    - name: Setup Node.js from version file
+      uses: actions/setup-node@v3
+      if: inputs.node-version-file != ''
+      with:
+        node-version-file: ${{ inputs.node-version-file }}
 
     - name: Auth to Nexus npm registry
       if: inputs.GAR_WORKFLOW != 'true'

--- a/composite-actions/frontend-generic/upload-source-maps/action.yaml
+++ b/composite-actions/frontend-generic/upload-source-maps/action.yaml
@@ -51,14 +51,8 @@ runs:
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
-      if: inputs.node-version-file == ''
       with:
-        node-version: ${{ inputs.node-version }}
-
-    - name: Setup Node.js from version file
-      uses: actions/setup-node@v3
-      if: inputs.node-version-file != ''
-      with:
+        node-version: ${{ inputs.node-version-file == '' && inputs.node-version || '' }}
         node-version-file: ${{ inputs.node-version-file }}
 
     - name: Auth to Nexus npm registry

--- a/composite-actions/frontend-generic/upload-source-maps/action.yaml
+++ b/composite-actions/frontend-generic/upload-source-maps/action.yaml
@@ -24,6 +24,10 @@ inputs:
     description: "Use GAR auth workflow (true/false)"
     required: false
     default: "false"
+  node-version:
+    description: 'Node.js version to use'
+    required: false
+    default: '20'
 
 runs:
   using: composite
@@ -44,7 +48,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: "20"
+        node-version: ${{ inputs.node-version }}
 
     - name: Auth to Nexus npm registry
       if: inputs.GAR_WORKFLOW != 'true'

--- a/composite-actions/frontend-generic/upload-source-maps/action.yaml
+++ b/composite-actions/frontend-generic/upload-source-maps/action.yaml
@@ -50,13 +50,13 @@ runs:
         fetch-depth: 0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       if: inputs.node-version-file == ''
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Setup Node.js from version file
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       if: inputs.node-version-file != ''
       with:
         node-version-file: ${{ inputs.node-version-file }}


### PR DESCRIPTION
## Summary

Adds a \
ode-version\ input (optional, default \'20'\) to all frontend-generic composite actions that previously hardcoded \
ode-version: 20\ in their \ctions/setup-node\ step.

## Changed files
- \composite-actions/frontend-generic/test/action.yaml\
- \composite-actions/frontend-generic/prod-deploy/action.yaml\
- \composite-actions/frontend-generic/prod-cloud-deploy/action.yaml\
- \composite-actions/frontend-generic/upload-source-maps/action.yaml\

## Behaviour
- No breaking change — existing callers that do not pass \
ode-version\ will continue to use Node 20.
- Callers that need a different Node version can now pass it explicitly.