### PR TITLE
fix(HII-13664): Align Trivy CVSS threshold with SRE bot alerts

### DIFF
--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -15,6 +15,10 @@ inputs:
     default: false
     type: boolean
     required: false
+  cvss-score-threshold:
+    description: "CVSS score at or above which the vulnerability scan fails the build. Aligned with the SRE bot alert threshold."
+    default: '7.5'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -140,6 +144,9 @@ runs:
         image: ${{ steps.scan-image.outputs.image }}
         service-account-key: ${{ inputs.GCLOUD_AUTH }}
         fail-on-vulnerabilities: true
+        # Match the threshold the SRE bot alerts on, so the build fails on the
+        # same CVEs that get reported to Slack (default here would be 9.5).
+        cvss-score-threshold: ${{ inputs.cvss-score-threshold }}
         notify-slack-on-vulnerabilities: false
 
     - name: Analyze with SonarCloud

--- a/composite-actions/nodejs-generic-api/test-unit/action.yaml
+++ b/composite-actions/nodejs-generic-api/test-unit/action.yaml
@@ -16,7 +16,7 @@ inputs:
     type: boolean
     required: false
   cvss-score-threshold:
-    description: "CVSS score at or above which the vulnerability scan fails the build. Aligned with the SRE bot alert threshold."
+    description: "CVSS score at or above which a CRITICAL vulnerability fails the build. Aligned with the SRE bot alert threshold."
     default: '7.5'
     required: false
 runs:
@@ -144,6 +144,10 @@ runs:
         image: ${{ steps.scan-image.outputs.image }}
         service-account-key: ${{ inputs.GCLOUD_AUTH }}
         fail-on-vulnerabilities: true
+        # Gate on CRITICAL only. The action derives its pass/fail from the max
+        # CVSS score across the whole report, so leaving HIGH in scope would
+        # fail the build on any HIGH CVE (that band starts at 7.0).
+        severity: 'CRITICAL'
         # Match the threshold the SRE bot alerts on, so the build fails on the
         # same CVEs that get reported to Slack (default here would be 9.5).
         cvss-score-threshold: ${{ inputs.cvss-score-threshold }}


### PR DESCRIPTION
## Summary

The `trivy-scan` action defaults `cvss-score-threshold` to `9.5`, so `nodejs-generic-api/test-unit` builds stayed green on the score-7.5 CVEs that the SRE bot reports as critical in Slack.

