### PR TITLE
fix(spanner-pgadapter-liquibase): resolve PGAdapter container IP instead of localhost

### DIFF
--- a/composite-actions/fiscal/spanner-pgadapter-liquibase/action.yaml
+++ b/composite-actions/fiscal/spanner-pgadapter-liquibase/action.yaml
@@ -46,6 +46,7 @@ runs:
         service-account-key: ${{ inputs.service-account-key }}
 
     - name: Start PGAdapter
+      id: pgadapter
       shell: bash
       run: |
         if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
@@ -62,7 +63,16 @@ runs:
           -p "${{ inputs.project }}" -i "${{ inputs.instance }}" -x
         # PGAdapter is the last thing to open the port; wait until it accepts TCP.
         for i in $(seq 1 30); do
-          if (exec 3<>/dev/tcp/localhost/5432) 2>/dev/null; then echo "PGAdapter ready"; exit 0; fi
+          if (exec 3<>/dev/tcp/localhost/5432) 2>/dev/null; then
+            echo "PGAdapter ready"
+            # The Liquibase step below is itself a docker container action, running in
+            # its own network namespace. It can't reach PGAdapter via "localhost" even
+            # though this readiness check (which runs directly on the runner host) can.
+            # Resolve PGAdapter's bridge-network IP, which sibling containers can route to.
+            ip=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' pgadapter)
+            echo "ip=$ip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           sleep 1
         done
         echo "PGAdapter did not become ready" >&2
@@ -78,7 +88,7 @@ runs:
       with:
         changelogFile: ${{ inputs.changelog-file }}
         searchPath: ${{ inputs.search-path }}
-        url: 'jdbc:postgresql://localhost:5432/${{ inputs.database }}?options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction'
+        url: 'jdbc:postgresql://${{ steps.pgadapter.outputs.ip }}:5432/${{ inputs.database }}?options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction'
         username: spanner
         password: spanner
 


### PR DESCRIPTION
## Summary
- The Liquibase `update` step in this composite action is itself a docker container action, running in its own network namespace, separate from the PGAdapter container started earlier in the same job.
- The JDBC URL used `localhost:5432`, which only worked for the readiness check (which runs directly on the runner host). From inside the sibling Liquibase container, `localhost` resolves to its own loopback, so the connection is refused.
- Both containers land on Docker's default `bridge` network (neither passes `--network`), so they can already route to each other by IP. This resolves PGAdapter's actual container IP after it becomes ready and uses that in the JDBC URL instead of `localhost`.

Surfaced while debugging `hiiretail-fiscal-signing-be`'s `deploy-staging` pipeline — a separate `JAVA_HOME` leak from `actions/setup-java` was previously killing that job before it ever reached this step, so this bug was never exercised.

## Test plan
- [ ] Run a consumer workflow (e.g. `hiiretail-fiscal-signing-be` `deploy-staging`) against this branch and confirm the "Apply DB migrations" step connects successfully instead of `Connection refused`.
- [ ] Confirm the `Stop PGAdapter` step still tears down the container on both success and failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)