### PR TITLE
fix: Run Liquibase as a self-managed container in spanner-pgadapter-liquibase

### DIFF
--- a/composite-actions/fiscal/spanner-pgadapter-liquibase/README.md
+++ b/composite-actions/fiscal/spanner-pgadapter-liquibase/README.md
@@ -23,6 +23,7 @@ This is a shared composite action, consumed as
 | `search-path` | yes | – | Directory containing the changelog and its includes. |
 | `changelog-file` | no | `changelog-master.yaml` | Changelog file, relative to `search-path`. |
 | `pgadapter-image` | no | pinned in `action.yaml` | PGAdapter image (tag+digest). |
+| `liquibase-image` | no | pinned in `action.yaml` | Liquibase image (tag+digest); bundles the PostgreSQL JDBC driver. |
 
 ## Notes / validation status
 
@@ -34,6 +35,8 @@ This is a shared composite action, consumed as
   PGAdapter converts Liquibase's transactional DDL into Spanner DDL batches.
 - The fiscal changesets ship on the `fiscal-engine` jar, so callers extract them first
   (e.g. `mvn dependency:unpack-dependencies`) and pass the directory as `search-path`.
-- **Not yet validated in CI against a real Spanner instance.** The PGAdapter flags and the
-  `liquibase-github-actions/update` input names should be confirmed on a first run before
-  relying on it for prod.
+- Liquibase runs as a **self-managed** `docker run --network host` (not the
+  `liquibase-github-actions/update` container action). `--network host` is what lets the
+  container reach PGAdapter on the runner's `localhost:5432`, and the `search-path` is
+  bind-mounted and referenced by a container path — a containerised action would see neither
+  the host `localhost` nor the host path. Linux-only semantics; correct on `ubuntu-latest`.

--- a/composite-actions/fiscal/spanner-pgadapter-liquibase/action.yaml
+++ b/composite-actions/fiscal/spanner-pgadapter-liquibase/action.yaml
@@ -34,6 +34,14 @@ inputs:
       periodically and bump both the tag and digest together by hand.
     required: false
     default: 'gcr.io/cloud-spanner-pg-adapter/pgadapter:v0.55.0@sha256:30bb42ded681effccf83f93e5f5107c1ef9e5e48513d0f7e1d30c7bfc69fa5fa'
+  liquibase-image:
+    description: >-
+      Liquibase image. Pinned by digest for immutability (Dependabot's docker ecosystem only
+      scans Dockerfile/docker-compose.yml, not action.yaml inputs, so this is NOT auto-updated —
+      check https://hub.docker.com/r/liquibase/liquibase/tags periodically and bump both the tag
+      and digest together by hand). The official image bundles the PostgreSQL JDBC driver.
+    required: false
+    default: 'liquibase/liquibase:4.25.1@sha256:c1ade9ef79b5966b0bd49f9a49c021fca08a90527008bb8d6346f31ab6070e67'
 
 runs:
   using: composite
@@ -52,6 +60,9 @@ runs:
           echo "GOOGLE_APPLICATION_CREDENTIALS not set; setup-gcloud must run first" >&2
           exit 1
         fi
+        # Best-effort clean of any leftover container from a crashed prior run (a no-op on
+        # ephemeral GitHub-hosted runners; guards reused/self-hosted runners against a name clash).
+        docker rm -f pgadapter 2>/dev/null || true
         # Mount the credential FILE (a path, not the secret value) and let PGAdapter pick it
         # up via Application Default Credentials.
         docker run -d --name pgadapter \
@@ -69,18 +80,45 @@ runs:
         docker logs pgadapter || true
         exit 1
 
-    # ddl_transaction_mode=AutocommitExplicitTransaction makes PGAdapter turn the
-    # transactional DDL Liquibase emits into Spanner DDL batches (Spanner forbids
-    # DDL inside explicit transactions). PGAdapter authenticates to Spanner via the
-    # mounted key, so the client-side username/password are unused.
+    # Liquibase runs as a SELF-MANAGED container (not the liquibase-github-actions/update
+    # container action, which the runner executes in an isolated network + filesystem
+    # namespace where `localhost` is not the host and host paths are not mounted). Here this
+    # action controls both:
+    #   * --network host makes the container's localhost:5432 the runner's localhost, where
+    #     PGAdapter published its port (-p 5432:5432) — so no URL change and no PGAdapter
+    #     change are needed. (Linux-only semantics; correct on GitHub-hosted ubuntu-latest.)
+    #   * the search-path dir is bind-mounted and referenced by a CONTAINER path.
+    # Settings are passed as LIQUIBASE_* env vars (same convention as
+    # extenda/actions/liquibase-spanner), so `update` is the only positional token and there
+    # is no CLI arg-ordering ambiguity. JAVA_HOME is deliberately NOT forwarded, so the
+    # runner's host JAVA_HOME cannot leak in and misdirect the launcher.
+    # ddl_transaction_mode=AutocommitExplicitTransaction makes PGAdapter turn the transactional
+    # DDL Liquibase emits into Spanner DDL batches (Spanner forbids DDL inside explicit
+    # transactions). PGAdapter authenticates to Spanner via the mounted key, so the client-side
+    # username/password are unused.
     - name: Run Liquibase update
-      uses: liquibase-github-actions/update@db87f3cf24f450dd01a6784a4cd7feec97a21676 # v4.25.1
-      with:
-        changelogFile: ${{ inputs.changelog-file }}
-        searchPath: ${{ inputs.search-path }}
-        url: 'jdbc:postgresql://localhost:5432/${{ inputs.database }}?options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction'
-        username: spanner
-        password: spanner
+      shell: bash
+      env:
+        SEARCH_PATH: ${{ inputs.search-path }}
+        LIQUIBASE_IMAGE: ${{ inputs.liquibase-image }}
+        LIQUIBASE_COMMAND_CHANGELOG_FILE: ${{ inputs.changelog-file }}
+        LIQUIBASE_COMMAND_URL: 'jdbc:postgresql://localhost:5432/${{ inputs.database }}?options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction'
+        LIQUIBASE_COMMAND_USERNAME: spanner
+        LIQUIBASE_COMMAND_PASSWORD: spanner
+        LIQUIBASE_SEARCH_PATH: /liquibase/changelog
+      run: |
+        set -euo pipefail
+        # Absolute path required so `docker -v` treats it as a bind mount, not a named volume.
+        SEARCH_PATH="$(realpath "${SEARCH_PATH}")"
+        docker run --rm --network host \
+          -v "${SEARCH_PATH}:/liquibase/changelog:ro" \
+          -e LIQUIBASE_SEARCH_PATH \
+          -e LIQUIBASE_COMMAND_CHANGELOG_FILE \
+          -e LIQUIBASE_COMMAND_URL \
+          -e LIQUIBASE_COMMAND_USERNAME \
+          -e LIQUIBASE_COMMAND_PASSWORD \
+          "${LIQUIBASE_IMAGE}" \
+          update
 
     - name: Stop PGAdapter
       if: always()


### PR DESCRIPTION
## Problem

`deploy-staging` in `extenda/hiiretail-fiscal-signing-be` fails at the `spanner-pgadapter-liquibase` action ([failed run](https://github.com/extenda/hiiretail-fiscal-signing-be/actions/runs/31366931972/job/93388097880)) with:

```
Non-existent directory: /home/runner/.../target/engine-liquibase/liquibase
Connection to localhost:5432 refused
```

PGAdapter itself was healthy — the host readiness probe printed `PGAdapter ready`. First-run bug (the action has a single commit, #373), not a regression.

## Root cause

Liquibase ran via the third-party `liquibase-github-actions/update` **container action**, which the runner executes as `docker run <image>` in an isolated network + filesystem namespace (only the workspace bind-mounted). So inside that container:

1. `jdbc:postgresql://localhost:5432` is the **container's own loopback**, not the host where PGAdapter published `:5432` → `Connection refused`.
2. The **absolute host path** passed as `searchPath` isn't mounted into the container → `Non-existent directory`.

The sibling `spanner-pgadapter-execute-sql` works because it runs `psql` in a host `shell: bash` step. And `extenda/actions/liquibase-spanner` deliberately avoids the container action, running Liquibase via a self-managed `docker run` with container-relative paths — the model followed here.

## Fix

- Replace the container-action step with a **self-managed `docker run --network host`** of the digest-pinned `liquibase/liquibase:4.25.1`, passing settings as `LIQUIBASE_*` env vars and bind-mounting the changelog at a container path. `--network host` gives the container the runner's `localhost`, so **PGAdapter (`-p 5432:5432`), the readiness probe, and the JDBC URL are unchanged**. (Linux-only semantics; correct on `ubuntu-latest`.)
- Add a digest-pinned `liquibase-image` input, matching the `pgadapter-image` immutability convention.
- Hardening: pre-clean any leftover `pgadapter` container before start; `realpath` the mount path.
- `-x` on PGAdapter is retained (connections arrive via published-port NAT, so PGAdapter sees a non-localhost source).

## Verification

- Digest `sha256:c1ade9ef…` confirmed as the multi-arch manifest-list digest for `liquibase/liquibase:4.25.1`.
- Locally ran the pinned image with the exact `LIQUIBASE_*` env-var contract + a bind-mounted changelog: **no `Non-existent directory`, no arg-parse errors** — it loads `org.postgresql.Driver`, reads the changelog, and reaches the connection stage (fails only because there's no local DB, as expected).
- Full Spanner connectivity needs a `deploy-staging` re-run: expect `PGAdapter ready`, changesets applied, exit 0, and neither original error.

## Optional follow-up (other repo)

The `Clear JAVA_HOME before Liquibase container step` in `hiiretail-fiscal-signing-be`'s `commit.yaml` is now a harmless no-op (the self-managed run never forwards `JAVA_HOME`) — safe to leave or remove later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)