### PR TITLE
fix: Mount credential dir into PGAdapter for WIF compatibility

### DIFF
--- a/composite-actions/fiscal/spanner-pgadapter-execute-sql/action.yaml
+++ b/composite-actions/fiscal/spanner-pgadapter-execute-sql/action.yaml
@@ -47,12 +47,21 @@ runs:
           echo "GOOGLE_APPLICATION_CREDENTIALS not set; setup-gcloud must run first" >&2
           exit 1
         fi
-        # Mount the credential FILE (a path, not the secret value) and let PGAdapter pick it
-        # up via Application Default Credentials.
+        # Best-effort clean of any leftover container from a crashed prior run (a no-op on
+        # ephemeral GitHub-hosted runners; guards reused/self-hosted runners against a name clash).
+        docker rm -f pgadapter 2>/dev/null || true
+        # Mount the credential DIRECTORY (not just the one file) at its original host path and
+        # let PGAdapter pick up the credentials via Application Default Credentials. Under
+        # Workload Identity Federation, GOOGLE_APPLICATION_CREDENTIALS is an external-account
+        # config that references a SECOND file (the OIDC token) in the same job-scoped dir by
+        # its absolute host path — so the dir must be mounted at that same path and the env var
+        # passed through unchanged, otherwise PGAdapter fails with "UNAUTHENTICATED: Failed
+        # computing credential metadata". A legacy self-contained JSON key also works this way.
+        CRED_DIR="$(dirname "${GOOGLE_APPLICATION_CREDENTIALS}")"
         docker run -d --name pgadapter \
           -p 5432:5432 \
-          -v "${GOOGLE_APPLICATION_CREDENTIALS}:/var/run/secrets/gcp-credentials.json:ro" \
-          -e GOOGLE_APPLICATION_CREDENTIALS=/var/run/secrets/gcp-credentials.json \
+          -v "${CRED_DIR}:${CRED_DIR}:ro" \
+          -e GOOGLE_APPLICATION_CREDENTIALS \
           "${{ inputs.pgadapter-image }}" \
           -p "${{ inputs.project }}" -i "${{ inputs.instance }}" -x
         # PGAdapter is the last thing to open the port; wait until it accepts TCP.

--- a/composite-actions/fiscal/spanner-pgadapter-liquibase/README.md
+++ b/composite-actions/fiscal/spanner-pgadapter-liquibase/README.md
@@ -28,9 +28,12 @@ This is a shared composite action, consumed as
 ## Notes / validation status
 
 - **Credentials** are handled by `extenda/actions/setup-gcloud@v0` (same as
-  `cloud-sql-liquibase`): the action exports `GOOGLE_APPLICATION_CREDENTIALS`, and only that
-  file *path* is mounted into the PGAdapter container, which then uses Application Default
-  Credentials. The key value is never interpolated into a shell command or written by hand.
+  `cloud-sql-liquibase`): the action exports `GOOGLE_APPLICATION_CREDENTIALS`, and its
+  job-scoped credential *directory* is mounted into the PGAdapter container at its original
+  host path, which then uses Application Default Credentials. The directory (not just the one
+  file) is mounted because under Workload Identity Federation the exported config references a
+  second OIDC-token file in the same dir by absolute path. The key value is never interpolated
+  into a shell command or written by hand.
 - Sets `spanner.ddl_transaction_mode=AutocommitExplicitTransaction` on the connection so
   PGAdapter converts Liquibase's transactional DDL into Spanner DDL batches.
 - The fiscal changesets ship on the `fiscal-engine` jar, so callers extract them first

--- a/composite-actions/fiscal/spanner-pgadapter-liquibase/action.yaml
+++ b/composite-actions/fiscal/spanner-pgadapter-liquibase/action.yaml
@@ -63,12 +63,18 @@ runs:
         # Best-effort clean of any leftover container from a crashed prior run (a no-op on
         # ephemeral GitHub-hosted runners; guards reused/self-hosted runners against a name clash).
         docker rm -f pgadapter 2>/dev/null || true
-        # Mount the credential FILE (a path, not the secret value) and let PGAdapter pick it
-        # up via Application Default Credentials.
+        # Mount the credential DIRECTORY (not just the one file) at its original host path and
+        # let PGAdapter pick up the credentials via Application Default Credentials. Under
+        # Workload Identity Federation, GOOGLE_APPLICATION_CREDENTIALS is an external-account
+        # config that references a SECOND file (the OIDC token) in the same job-scoped dir by
+        # its absolute host path — so the dir must be mounted at that same path and the env var
+        # passed through unchanged, otherwise PGAdapter fails with "UNAUTHENTICATED: Failed
+        # computing credential metadata". A legacy self-contained JSON key also works this way.
+        CRED_DIR="$(dirname "${GOOGLE_APPLICATION_CREDENTIALS}")"
         docker run -d --name pgadapter \
           -p 5432:5432 \
-          -v "${GOOGLE_APPLICATION_CREDENTIALS}:/var/run/secrets/gcp-credentials.json:ro" \
-          -e GOOGLE_APPLICATION_CREDENTIALS=/var/run/secrets/gcp-credentials.json \
+          -v "${CRED_DIR}:${CRED_DIR}:ro" \
+          -e GOOGLE_APPLICATION_CREDENTIALS \
           "${{ inputs.pgadapter-image }}" \
           -p "${{ inputs.project }}" -i "${{ inputs.instance }}" -x
         # PGAdapter is the last thing to open the port; wait until it accepts TCP.


### PR DESCRIPTION
Follow-up to #379. That PR fixed the Liquibase↔PGAdapter networking/path errors; the deploy then progressed to the **next** failure — PGAdapter authenticating to Spanner ([failed run](https://github.com/extenda/hiiretail-fiscal-signing-be/actions/runs/31377184561/job/93436035442)):

```
FATAL: UNAUTHENTICATED: io.grpc.StatusRuntimeException: UNAUTHENTICATED: Failed computing credential metadata
```

## Root cause

The repo authenticates via **Workload Identity Federation**, so `extenda/actions/setup-gcloud` writes **two** files into one job-scoped dir under `$RUNNER_TEMP`:
1. `GOOGLE_APPLICATION_CREDENTIALS` → an **external-account config**, which references
2. the **OIDC token** file, by its **absolute host path** (`gcloud … create-cred-config --credential-source-file=<idTokenPath>`).

The action mounted only file #1, at a **remapped** path (`/var/run/secrets/gcp-credentials.json`). Inside the container PGAdapter reads the config, follows the absolute reference to file #2 — which isn't mounted — and fails to compute credentials. (A self-contained JSON key would have worked, which is why this only surfaced under WIF.)

## Fix

Mount the **credential directory** at its **original host path** (read-only) and forward `GOOGLE_APPLICATION_CREDENTIALS` **unchanged**, so both the config and the referenced token resolve at their real paths inside the container — mirroring the prior-art `extenda/actions/liquibase-spanner`, which mounts `$RUNNER_TEMP` at its own path. Works for both WIF and a legacy self-contained key.

```diff
-          -v "${GOOGLE_APPLICATION_CREDENTIALS}:/var/run/secrets/gcp-credentials.json:ro" \
-          -e GOOGLE_APPLICATION_CREDENTIALS=/var/run/secrets/gcp-credentials.json \
+          -v "${CRED_DIR}:${CRED_DIR}:ro" \
+          -e GOOGLE_APPLICATION_CREDENTIALS \
```

Applied to **both** `spanner-pgadapter-liquibase` and the sibling `spanner-pgadapter-execute-sql` (identical `Start PGAdapter` step, same latent bug), and added a best-effort `docker rm -f pgadapter` pre-clean.

## Verification

- Reproduced the mount mechanic locally: with the **old** single-file mount the config's absolute reference to the OIDC token is unreadable in the container (the `UNAUTHENTICATED` cause); with the **new** dir mount both the config and the referenced token resolve at their original paths.
- Full Spanner auth needs a `deploy-staging` re-run: expect `PGAdapter ready`, changesets applied, exit 0, and no `UNAUTHENTICATED` error.