### PR TITLE
feat: Build Liquibase 5.0.3 image with LPM-installed Postgres driver

### DIFF
--- a/composite-actions/fiscal/spanner-pgadapter-liquibase/Dockerfile
+++ b/composite-actions/fiscal/spanner-pgadapter-liquibase/Dockerfile
@@ -1,0 +1,22 @@
+# Liquibase image used by this action. Built here rather than pulled directly because
+# Liquibase 5.x Community images ship NO JDBC drivers (only h2) — running `update` against
+# Postgres with the stock image fails with "Cannot find database driver: org.postgresql.Driver".
+# The driver is installed with LPM (the Liquibase Package Manager).
+#
+# Both versions are build args so callers can override them via the action's
+# liquibase-version / postgres-driver-version inputs; the defaults below are the pinned
+# baseline and must be kept in sync with the defaults in action.yaml.
+ARG LIQUIBASE_VERSION=5.0.3
+FROM liquibase/liquibase:${LIQUIBASE_VERSION}
+
+# Pinned to an exact driver version so a rebuild is reproducible (LPM would otherwise resolve
+# the latest available driver at build time). Which driver versions exist is decided by the
+# LPM index of the Liquibase version above — e.g. 42.7.11 is available on 5.0.3 but not on
+# 5.0.2 — so passing an empty POSTGRES_DRIVER_VERSION falls back to whatever that release
+# offers, letting a liquibase-version override work without also hunting for a matching driver.
+ARG POSTGRES_DRIVER_VERSION=42.7.11
+RUN if [ -n "${POSTGRES_DRIVER_VERSION}" ]; then \
+      lpm add "postgresql@${POSTGRES_DRIVER_VERSION}" --global; \
+    else \
+      lpm add postgresql --global; \
+    fi

--- a/composite-actions/fiscal/spanner-pgadapter-liquibase/README.md
+++ b/composite-actions/fiscal/spanner-pgadapter-liquibase/README.md
@@ -23,7 +23,8 @@ This is a shared composite action, consumed as
 | `search-path` | yes | – | Directory containing the changelog and its includes. |
 | `changelog-file` | no | `changelog-master.yaml` | Changelog file, relative to `search-path`. |
 | `pgadapter-image` | no | pinned in `action.yaml` | PGAdapter image (tag+digest). |
-| `liquibase-image` | no | pinned in `action.yaml` | Liquibase image (tag+digest); bundles the PostgreSQL JDBC driver. |
+| `liquibase-version` | no | `5.0.3` | Liquibase version; tag of the base image the action builds from. |
+| `postgres-driver-version` | no | `42.7.11` | PostgreSQL JDBC driver version installed with LPM. Set to `''` to take whatever the chosen Liquibase release offers. |
 
 ## Notes / validation status
 
@@ -43,3 +44,16 @@ This is a shared composite action, consumed as
   container reach PGAdapter on the runner's `localhost:5432`, and the `search-path` is
   bind-mounted and referenced by a container path — a containerised action would see neither
   the host `localhost` nor the host path. Linux-only semantics; correct on `ubuntu-latest`.
+- The Liquibase image is **built by this action** from its `Dockerfile` rather than pulled.
+  Liquibase 5.x Community images ship **no JDBC drivers** (only h2), so the stock image fails
+  with `Cannot find database driver: org.postgresql.Driver`; the driver is installed on top
+  with [LPM](https://docs.liquibase.com/community/integration-guide-5-0/connect-liquibase-with-postgresql)
+  (`lpm add postgresql@<version> --global`). Both versions are `--build-arg`s fed from the
+  `liquibase-version` / `postgres-driver-version` inputs, whose defaults are the pinned
+  baseline — keep the Dockerfile `ARG` defaults in sync with the `action.yaml` defaults.
+  Because the `FROM` tag is parameterised it is not Dependabot-scannable; bump the defaults by
+  hand (check [Liquibase tags](https://hub.docker.com/r/liquibase/liquibase/tags)).
+  Note the two versions are coupled: which driver versions exist is decided by the LPM index of
+  the chosen Liquibase release (`42.7.11` resolves on 5.0.3 but not on 5.0.2), so when
+  overriding `liquibase-version` either pick a driver that release ships or pass
+  `postgres-driver-version: ''` to accept its default.

--- a/composite-actions/fiscal/spanner-pgadapter-liquibase/action.yaml
+++ b/composite-actions/fiscal/spanner-pgadapter-liquibase/action.yaml
@@ -34,14 +34,21 @@ inputs:
       periodically and bump both the tag and digest together by hand.
     required: false
     default: 'gcr.io/cloud-spanner-pg-adapter/pgadapter:v0.55.0@sha256:30bb42ded681effccf83f93e5f5107c1ef9e5e48513d0f7e1d30c7bfc69fa5fa'
-  liquibase-image:
+  liquibase-version:
     description: >-
-      Liquibase image. Pinned by digest for immutability (Dependabot's docker ecosystem only
-      scans Dockerfile/docker-compose.yml, not action.yaml inputs, so this is NOT auto-updated —
-      check https://hub.docker.com/r/liquibase/liquibase/tags periodically and bump both the tag
-      and digest together by hand). The official image bundles the PostgreSQL JDBC driver.
+      Liquibase version, used as the tag of the liquibase/liquibase base image the action
+      builds from (see this action's Dockerfile). 5.x Community images ship no JDBC drivers,
+      so the PostgreSQL driver is installed on top with LPM.
     required: false
-    default: 'liquibase/liquibase:4.25.1@sha256:c1ade9ef79b5966b0bd49f9a49c021fca08a90527008bb8d6346f31ab6070e67'
+    default: '5.0.3'
+  postgres-driver-version:
+    description: >-
+      PostgreSQL JDBC driver version installed into the Liquibase image with LPM. Pinned to an
+      exact version so rebuilds are reproducible. Which versions exist depends on the LPM index
+      of the chosen liquibase-version (42.7.11 resolves on 5.0.3 but not on 5.0.2), so set this
+      to '' to accept whatever driver that release offers.
+    required: false
+    default: '42.7.11'
 
 runs:
   using: composite
@@ -52,6 +59,21 @@ runs:
     - uses: extenda/actions/setup-gcloud@v0
       with:
         service-account-key: ${{ inputs.service-account-key }}
+
+    # Built (not pulled) because Liquibase 5.x ships no JDBC drivers — see the Dockerfile.
+    # Built before PGAdapter starts so a build failure costs nothing to tear down.
+    - name: Build Liquibase image
+      shell: bash
+      env:
+        LIQUIBASE_VERSION: ${{ inputs.liquibase-version }}
+        POSTGRES_DRIVER_VERSION: ${{ inputs.postgres-driver-version }}
+      run: |
+        set -euo pipefail
+        docker build \
+          --build-arg "LIQUIBASE_VERSION=${LIQUIBASE_VERSION}" \
+          --build-arg "POSTGRES_DRIVER_VERSION=${POSTGRES_DRIVER_VERSION}" \
+          -t liquibase-pg:local \
+          "${{ github.action_path }}"
 
     - name: Start PGAdapter
       shell: bash
@@ -106,7 +128,6 @@ runs:
       shell: bash
       env:
         SEARCH_PATH: ${{ inputs.search-path }}
-        LIQUIBASE_IMAGE: ${{ inputs.liquibase-image }}
         LIQUIBASE_COMMAND_CHANGELOG_FILE: ${{ inputs.changelog-file }}
         LIQUIBASE_COMMAND_URL: 'jdbc:postgresql://localhost:5432/${{ inputs.database }}?options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction'
         LIQUIBASE_COMMAND_USERNAME: spanner
@@ -123,7 +144,7 @@ runs:
           -e LIQUIBASE_COMMAND_URL \
           -e LIQUIBASE_COMMAND_USERNAME \
           -e LIQUIBASE_COMMAND_PASSWORD \
-          "${LIQUIBASE_IMAGE}" \
+          liquibase-pg:local \
           update
 
     - name: Stop PGAdapter


### PR DESCRIPTION
Follow-up to #379/#380. The action pulled `liquibase/liquibase:4.25.1` — a version originally chosen only to match the `liquibase-github-actions/update` container action it used to wrap. That constraint disappeared when #379 moved Liquibase to a self-managed container, leaving us pinned two years and a major version behind.

## Why a Dockerfile rather than just bumping the tag

**Liquibase 5.x Community images ship no JDBC drivers** — only `h2`. Pulling 5.0.3 directly fails:

```
ERROR: Exception Primary Reason:  Cannot find database driver: org.postgresql.Driver
```

Verified by inspecting both images:

| | 4.25.1 (before) | 4.33.0 | 5.0.3 (now) |
|---|---|---|---|
| bundled driver | `postgresql.jar` | `postgresql.jar` | **only `h2.jar`** |

The supported fix is the Liquibase Package Manager ([docs](https://docs.liquibase.com/community/integration-guide-5-0/connect-liquibase-with-postgresql), [docker README](https://github.com/liquibase/docker/blob/main/README.md)), so the action now builds its image from a `Dockerfile` and runs `lpm add postgresql@<version> --global`. This mirrors the prior-art `extenda/actions/liquibase-spanner`, which also builds from a Dockerfile in the action path.

## Versions are inputs

`liquibase-version` (default `5.0.3`) and `postgres-driver-version` (default `42.7.11`) are passed through as `--build-arg`s.

The driver pin is deliberately **optional**, because the two are coupled: which driver versions exist is decided by the LPM index of the chosen Liquibase release — `42.7.11` resolves on 5.0.3 but **not** on 5.0.2. Passing `postgres-driver-version: ''` takes whatever that release offers, so a `liquibase-version` override works without hunting for a matching driver.

Replaces the `liquibase-image` input (added in #379), which has no callers — the only consumer is `hiiretail-fiscal-signing-be`, which does not set it.

## Verification

All run locally against a real Postgres, using the action's exact env-var contract and the Spanner-style `?options=-c%20spanner.ddl_transaction_mode=…` URL:

- Stock 5.0.3 fails with `Cannot find database driver` — reproduced the problem this PR solves.
- Built from this Dockerfile: `Liquibase Version: 5.0.3` + `postgresql-42.7.11.jar`; `update` applies the changeset and creates the table (`databasechangelog`, `databasechangeloglock`, `fiscal_seal`).
- Both build args verified to take effect: `LIQUIBASE_VERSION=5.0.2` + empty driver → `Liquibase Version: 5.0.2` + `postgresql-42.7.8.jar`.
- `action.yaml` parses as valid YAML.

Not covered locally: the Spanner PG-dialect behaviour of a major-version Liquibase jump — that needs a `deploy-staging` run. Note #380's WIF fix is also still unproven in CI (no run has fired since it merged), so if the next deploy fails, check which of the two layers it fails at.