### PR TITLE
fix: Verify PGAdapter readiness at the protocol level, not by TCP accept

### DIFF
--- a/composite-actions/fiscal/spanner-pgadapter-execute-sql/action.yaml
+++ b/composite-actions/fiscal/spanner-pgadapter-execute-sql/action.yaml
@@ -42,6 +42,8 @@ runs:
 
     - name: Start PGAdapter
       shell: bash
+      env:
+        DATABASE: ${{ inputs.database }}
       run: |
         if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
           echo "GOOGLE_APPLICATION_CREDENTIALS not set; setup-gcloud must run first" >&2
@@ -64,9 +66,21 @@ runs:
           -e GOOGLE_APPLICATION_CREDENTIALS \
           "${{ inputs.pgadapter-image }}" \
           -p "${{ inputs.project }}" -i "${{ inputs.instance }}" -x
-        # PGAdapter is the last thing to open the port; wait until it accepts TCP.
-        for i in $(seq 1 30); do
-          if (exec 3<>/dev/tcp/localhost/5432) 2>/dev/null; then echo "PGAdapter ready"; exit 0; fi
+        # Readiness has to be proven at the PostgreSQL protocol level, NOT by a TCP accept.
+        # Docker publishes the host port when the CONTAINER is created, so the port proxy
+        # accepts connections straight away while the PGAdapter JVM inside is still booting.
+        # A TCP probe therefore reports ready in ~200ms and hands the next client a connection
+        # the proxy has no backend for — psql reports "server closed the connection
+        # unexpectedly" (not "connection refused", which is what makes it confusing).
+        # pg_isready completes a real startup handshake, so it succeeds only once PGAdapter is
+        # actually serving. Probe 127.0.0.1 rather than localhost so the probe and the client
+        # agree on the address family — libpq tries localhost's ::1 first.
+        command -v pg_isready >/dev/null || {
+          echo "pg_isready not found; needs postgresql-client (preinstalled on ubuntu-latest)" >&2
+          exit 1
+        }
+        for i in $(seq 1 60); do
+          if pg_isready -q -h 127.0.0.1 -p 5432 -d "${DATABASE}"; then echo "PGAdapter ready"; exit 0; fi
           sleep 1
         done
         echo "PGAdapter did not become ready" >&2
@@ -82,9 +96,17 @@ runs:
         SQL: ${{ inputs.sql }}
         DATABASE: ${{ inputs.database }}
       run: |
-        printf '%s\n' "${SQL}" | psql \
-          "postgresql://spanner:spanner@localhost:5432/${DATABASE}?sslmode=disable" \
+        set -o pipefail
+        if ! printf '%s\n' "${SQL}" | psql \
+          "postgresql://spanner:spanner@127.0.0.1:5432/${DATABASE}?sslmode=disable" \
           -v ON_ERROR_STOP=1
+        then
+          # Without this the only evidence of a PGAdapter-side failure is psql's one-line
+          # client error; the container is torn down next and its logs are lost.
+          echo "psql failed — PGAdapter logs follow" >&2
+          docker logs pgadapter >&2 || true
+          exit 1
+        fi
 
     - name: Stop PGAdapter
       if: always()

--- a/composite-actions/fiscal/spanner-pgadapter-liquibase/README.md
+++ b/composite-actions/fiscal/spanner-pgadapter-liquibase/README.md
@@ -43,7 +43,15 @@ This is a shared composite action, consumed as
   `liquibase-github-actions/update` container action). `--network host` is what lets the
   container reach PGAdapter on the runner's `localhost:5432`, and the `search-path` is
   bind-mounted and referenced by a container path — a containerised action would see neither
-  the host `localhost` nor the host path. Linux-only semantics; correct on `ubuntu-latest`.
+  the host loopback nor the host path. Linux-only semantics; correct on `ubuntu-latest`.
+- PGAdapter readiness is checked with **`pg_isready`, not a TCP connect**. Docker publishes the
+  host port when the container is *created*, so the port proxy accepts connections long before
+  the PGAdapter JVM inside has bound anything: a TCP probe reports ready in ~200 ms and the
+  first client is handed a connection the proxy cannot forward, which surfaces as
+  `server closed the connection unexpectedly` rather than a refusal. `pg_isready` completes a
+  real startup handshake instead. It needs `postgresql-client` on the runner (preinstalled on
+  `ubuntu-latest`). Probes and clients address `127.0.0.1` explicitly, because `libpq` resolves
+  `localhost` to `::1` first and would otherwise not necessarily test the same endpoint.
 - The Liquibase image is **built by this action** from its `Dockerfile` rather than pulled.
   Liquibase 5.x Community images ship **no JDBC drivers** (only h2), so the stock image fails
   with `Cannot find database driver: org.postgresql.Driver`; the driver is installed on top

--- a/composite-actions/fiscal/spanner-pgadapter-liquibase/action.yaml
+++ b/composite-actions/fiscal/spanner-pgadapter-liquibase/action.yaml
@@ -77,6 +77,8 @@ runs:
 
     - name: Start PGAdapter
       shell: bash
+      env:
+        DATABASE: ${{ inputs.database }}
       run: |
         if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
           echo "GOOGLE_APPLICATION_CREDENTIALS not set; setup-gcloud must run first" >&2
@@ -99,9 +101,22 @@ runs:
           -e GOOGLE_APPLICATION_CREDENTIALS \
           "${{ inputs.pgadapter-image }}" \
           -p "${{ inputs.project }}" -i "${{ inputs.instance }}" -x
-        # PGAdapter is the last thing to open the port; wait until it accepts TCP.
-        for i in $(seq 1 30); do
-          if (exec 3<>/dev/tcp/localhost/5432) 2>/dev/null; then echo "PGAdapter ready"; exit 0; fi
+        # Readiness has to be proven at the PostgreSQL protocol level, NOT by a TCP accept.
+        # Docker publishes the host port when the CONTAINER is created, so the port proxy
+        # accepts connections straight away while the PGAdapter JVM inside is still booting.
+        # A TCP probe therefore reports ready in ~200ms and hands the next client a connection
+        # the proxy has no backend for. This action only ever got away with it because
+        # building and starting the Liquibase container bought PGAdapter several more seconds;
+        # its psql-based sibling runs its client ~150ms later and fails every time.
+        # pg_isready completes a real startup handshake, so it succeeds only once PGAdapter is
+        # actually serving. Probe 127.0.0.1 rather than localhost so the probe and the client
+        # agree on the address family — libpq tries localhost's ::1 first.
+        command -v pg_isready >/dev/null || {
+          echo "pg_isready not found; needs postgresql-client (preinstalled on ubuntu-latest)" >&2
+          exit 1
+        }
+        for i in $(seq 1 60); do
+          if pg_isready -q -h 127.0.0.1 -p 5432 -d "${DATABASE}"; then echo "PGAdapter ready"; exit 0; fi
           sleep 1
         done
         echo "PGAdapter did not become ready" >&2
@@ -112,7 +127,7 @@ runs:
     # container action, which the runner executes in an isolated network + filesystem
     # namespace where `localhost` is not the host and host paths are not mounted). Here this
     # action controls both:
-    #   * --network host makes the container's localhost:5432 the runner's localhost, where
+    #   * --network host makes the container's 127.0.0.1:5432 the runner's loopback, where
     #     PGAdapter published its port (-p 5432:5432) — so no URL change and no PGAdapter
     #     change are needed. (Linux-only semantics; correct on GitHub-hosted ubuntu-latest.)
     #   * the search-path dir is bind-mounted and referenced by a CONTAINER path.
@@ -129,7 +144,7 @@ runs:
       env:
         SEARCH_PATH: ${{ inputs.search-path }}
         LIQUIBASE_COMMAND_CHANGELOG_FILE: ${{ inputs.changelog-file }}
-        LIQUIBASE_COMMAND_URL: 'jdbc:postgresql://localhost:5432/${{ inputs.database }}?options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction'
+        LIQUIBASE_COMMAND_URL: 'jdbc:postgresql://127.0.0.1:5432/${{ inputs.database }}?options=-c%20spanner.ddl_transaction_mode=AutocommitExplicitTransaction'
         LIQUIBASE_COMMAND_USERNAME: spanner
         LIQUIBASE_COMMAND_PASSWORD: spanner
         LIQUIBASE_SEARCH_PATH: /liquibase/changelog
@@ -137,7 +152,7 @@ runs:
         set -euo pipefail
         # Absolute path required so `docker -v` treats it as a bind mount, not a named volume.
         SEARCH_PATH="$(realpath "${SEARCH_PATH}")"
-        docker run --rm --network host \
+        if ! docker run --rm --network host \
           -v "${SEARCH_PATH}:/liquibase/changelog:ro" \
           -e LIQUIBASE_SEARCH_PATH \
           -e LIQUIBASE_COMMAND_CHANGELOG_FILE \
@@ -146,6 +161,13 @@ runs:
           -e LIQUIBASE_COMMAND_PASSWORD \
           liquibase-pg:local \
           update
+        then
+          # A connection-side failure shows up only as a Liquibase client error; the
+          # container is torn down next and its logs are lost. Keep them.
+          echo "Liquibase failed — PGAdapter logs follow" >&2
+          docker logs pgadapter >&2 || true
+          exit 1
+        fi
 
     - name: Stop PGAdapter
       if: always()


### PR DESCRIPTION
## Problem

Both fiscal PGAdapter actions treat a successful TCP connect as proof that PGAdapter is serving:

```bash
# PGAdapter is the last thing to open the port; wait until it accepts TCP.
if (exec 3<>/dev/tcp/localhost/5432) 2>/dev/null; then echo "PGAdapter ready"; exit 0; fi
```

That comment is the wrong assumption. **Docker publishes the host port when the container is _created_**, so the port proxy accepts connections immediately — while the PGAdapter JVM inside is still booting. The probe returns ready in ~200 ms and hands the next client a connection the proxy has no backend for. That surfaces as `server closed the connection unexpectedly`, not `connection refused`, which is what makes it hard to read.

## Evidence

From `extenda/hiiretail-fiscal-signing-be` run [31386343481](https://github.com/extenda/hiiretail-fiscal-signing-be/actions/runs/31386343481):

| action | container created | `PGAdapter ready` | Δ | first client query |
|---|---|---|---|---|
| `execute-sql` ❌ | `12:42:52.064` | `12:42:52.283` | **219 ms** | +150 ms → `server closed the connection unexpectedly` |
| `liquibase` ✅ | `12:09:03.474` | `12:09:03.664` | **190 ms** | +1.4 s (JVM boot) → succeeds |

No JVM boots and binds a port in 200 ms, so **both** probes are false positives. `execute-sql` runs `psql` 150 ms later and loses the race — deterministically, meaning that action has never worked. `liquibase` survives only because building and starting the Liquibase container buys PGAdapter several extra seconds; it is latently broken and would fail the moment its client got faster.

## Changes

1. **Probe with `pg_isready`** — it completes a real startup handshake, so it succeeds only once PGAdapter is actually serving. Applied to both actions.
2. **Address `127.0.0.1`, not `localhost`**, in probes and clients. The failing `psql` resolved `localhost` to **`::1`** (visible in the error line), so the bash `/dev/tcp` probe and the client were not necessarily testing the same endpoint or even the same address family.
3. **Dump PGAdapter logs when the client step fails**, not only when the readiness loop times out. The failing run produced no container logs at all — the container is torn down immediately afterwards — which is why diagnosing this needed timestamp forensics rather than an error message.

## Trade-offs worth a reviewer's attention

- **New runner dependency:** `pg_isready` (from `postgresql-client`) is now required by `spanner-pgadapter-liquibase`, which previously needed only Docker. It is preinstalled on GitHub-hosted `ubuntu-latest` — which both actions already target explicitly for their `--network host` semantics — and `execute-sql` already required `psql` from the same package. It is checked up front so a missing binary gives a clear message rather than a timeout.
- **The published port stays `0.0.0.0`** (`-p 5432:5432`). Restricting it to `127.0.0.1` would be tighter, but it would break any consumer reaching PGAdapter from a bridge-network container, so it is deliberately left alone.
- The readiness loop goes from 30 to 60 iterations, since it now waits for real startup rather than for the proxy.

## Testing

Both `action.yaml` files parse as YAML, and every `run:` block passes `bash -n` with GitHub expressions substituted out. The race itself was diagnosed from CI timestamps rather than reproduced locally: Docker Desktop's port forwarder refuses early connections instead of accepting them, so it does not exhibit the Linux `docker-proxy` behaviour. The consuming repo's next `deploy-staging` and `acceptance` runs will exercise both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)