### PR TITLE
fix: Pass should-i-deploy values through env, not expression interpolation

### DIFF
--- a/generic/should-i-deploy/action.yaml
+++ b/generic/should-i-deploy/action.yaml
@@ -18,10 +18,17 @@ runs:
   steps:
     - name: Check if it is Monday to Thursday and within work hours
       shell: bash
+      # Values reach the script as environment variables, never as ${{ }} inside `run`.
+      # Expression substitution happens while the script is being generated, so the
+      # commit message would land in the shell source verbatim: a message containing a
+      # double quote ends the string and breaks parsing, and one containing $(...) or
+      # backticks executes on a runner that holds deploy credentials.
+      env:
+        TZ: ${{ inputs.time-zone }}
+        WORK_HOURS_START: ${{ inputs.work-hours-start }}
+        WORK_HOURS_END: ${{ inputs.work-hours-end }}
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
       run: |
-        export TZ="${{ inputs.time-zone }}"
-        COMMIT_MSG="${{ github.event.head_commit.message }}"
-
         if [[ "$COMMIT_MSG" == *"[force deploy]"* ]]; then
           echo "Force deploy detected in commit message. Proceeding..."
           exit 0
@@ -30,14 +37,14 @@ runs:
         CURRENT_TIME=$(date +%H:%M)
         DAY_OF_WEEK=$(date +%u)
         # 1=Monday, 2=Tuesday, 3=Wednesday, 4=Thursday, 5=Friday, 6=Saturday, 7=Sunday
-        
+
         if [ "$DAY_OF_WEEK" -le 4 ]; then
-          if [[ "$CURRENT_TIME" > "${{ inputs.work-hours-start }}" || "$CURRENT_TIME" == "${{ inputs.work-hours-start }}" ]] && \
-             [[ "$CURRENT_TIME" < "${{ inputs.work-hours-end }}" || "$CURRENT_TIME" == "${{ inputs.work-hours-end }}" ]]; then
+          if [[ "$CURRENT_TIME" > "$WORK_HOURS_START" || "$CURRENT_TIME" == "$WORK_HOURS_START" ]] && \
+             [[ "$CURRENT_TIME" < "$WORK_HOURS_END" || "$CURRENT_TIME" == "$WORK_HOURS_END" ]]; then
             echo "It's a good day and time to deploy!"
             exit 0
           else
-            echo "Deployment is only allowed during work hours (${{ inputs.work-hours-start }} - ${{ inputs.work-hours-end }}). Current time is $CURRENT_TIME."
+            echo "Deployment is only allowed during work hours ($WORK_HOURS_START - $WORK_HOURS_END). Current time is $CURRENT_TIME."
             exit 1
           fi
         else

--- a/generic/should-i-deploy/test.sh
+++ b/generic/should-i-deploy/test.sh
@@ -56,4 +56,37 @@ check_deploy "08:00" 1 "regular commit" || exit 1
 # Test Case 7: Edge case - exactly end time
 check_deploy "17:00" 1 "regular commit" || exit 1
 
+# Test Case 8: commit message containing shell metacharacters. Quotes and parentheses
+# are ordinary text in a commit body and must not affect the decision.
+check_deploy "10:00" 1 'fix: report bcprov "(version managed from 1.80)" in the tree' || exit 1
+
+# Test Case 9: force deploy still detected when the message carries metacharacters, and
+# no substitution is performed on it.
+canary="${TMPDIR:-/tmp}/should-i-deploy-canary.$$"
+rm -f "$canary"
+check_deploy "10:00" 5 '[force deploy] $(touch '"$canary"') and `touch '"$canary"'`' || exit 1
+if [ -e "$canary" ]; then
+    echo "FAILURE: commit message was evaluated by the shell"
+    rm -f "$canary"
+    exit 1
+fi
+echo "SUCCESS: commit message treated as data, not code"
+
+# Test Case 10: guard the actual defect. The bash above can only prove the logic is safe
+# once the message arrives as data; the real bug was that ${{ }} substitution pasted the
+# commit message straight into the generated shell source. Assert the run block contains
+# no expressions at all, so every value has to come in through `env:`.
+action_yaml="$(dirname "$0")/action.yaml"
+run_block=$(awk '/^      run: \|$/ {flag=1; next} flag' "$action_yaml")
+if [ -z "$run_block" ]; then
+    echo "FAILURE: could not locate the run block in $action_yaml"
+    exit 1
+fi
+if grep -q '\${{' <<<"$run_block"; then
+    echo "FAILURE: action.yaml interpolates an expression inside the run block:"
+    grep -n '\${{' <<<"$run_block"
+    exit 1
+fi
+echo "SUCCESS: run block contains no expression interpolation"
+
 echo "All tests passed!"


### PR DESCRIPTION
## The bug

`generic/should-i-deploy/action.yaml` built its shell script by interpolating GitHub expressions straight into the `run` block:

```yaml
run: |
  export TZ="${{ inputs.time-zone }}"
  COMMIT_MSG="${{ github.event.head_commit.message }}"
```

Expression substitution happens while the script is *generated*, so the commit message ends up in the shell **source**, not in a variable. The generated script is literally:

```bash
COMMIT_MSG="fix(deps): Take bcprov CVE fix from fiscal-engine 0.1.10 (#55)
...
0.1.10: dependency:tree reports bcprov-jdk18on:1.85.2 "(version managed
from 1.80)".
```

### Impact 1 — commit messages break the deploy gate

An ordinary double quote in a commit body closes the string, and the rest of the line parses as shell. Real failure in `extenda/hiiretail-fiscal-signing-be` ([run 31784781442](https://github.com/extenda/hiiretail-fiscal-signing-be/actions/runs/31784781442)):

```
/home/runner/work/_temp/....sh: line 11: syntax error near unexpected token `('
##[error]Process completed with exit code 2.
```

The step failed with a bash parse error rather than a deploy decision, which blocked `release` and `deploy-prod`. Any commit message containing a quote does this — it is a landmine for every repo using this action.

### Impact 2 — command injection

The same mechanism means a commit message containing `$(...)` or backticks is **executed** on the runner. That runner holds deploy credentials (`id-token: write`, service-account keys). Anyone who can land a commit — or open a PR that gets merged — can run arbitrary code in that context. This is the more serious half.

## The fix

All four values now arrive as environment variables, where the shell treats them as data:

```yaml
env:
  TZ: ${{ inputs.time-zone }}
  WORK_HOURS_START: ${{ inputs.work-hours-start }}
  WORK_HOURS_END: ${{ inputs.work-hours-end }}
  COMMIT_MSG: ${{ github.event.head_commit.message }}
run: |
  if [[ "$COMMIT_MSG" == *"[force deploy]"* ]]; then
```

No behaviour change: same schedule window, same `[force deploy]` bypass, same messages and exit codes. The three `inputs.*` values are fixed alongside the commit message — same class of bug, and they are set by calling workflows.

## Tests

`generic/should-i-deploy/test.sh` gains:

- **Case 8** — commit message with quotes and parentheses takes the normal path
- **Case 9** — `[force deploy]` still detected when the message carries `$(...)` and backticks, asserting via a canary file that nothing was evaluated
- **Case 10** — a guard asserting the `run` block contains **no** `${{ }}` at all, forcing every value through `env:`

Case 10 is the one that matters: bash tests cannot reproduce Actions-level interpolation, so the invariant is enforced against `action.yaml` itself. Verified it is not decorative — run against the previous `action.yaml` it exits 1 and reports all five interpolations:

```
FAILURE: action.yaml interpolates an expression inside the run block:
1:        export TZ="${{ inputs.time-zone }}"
2:        COMMIT_MSG="${{ github.event.head_commit.message }}"
...
```

Against this branch: `All tests passed!`, exit 0.

## Notes for reviewers

- `test.sh` is **not wired into CI** in this repo (`pull_request.yml` only runs commitlint), so the new guard will not run automatically. Happy to add a workflow that executes it, but I kept this PR to the fix so it can merge quickly — say the word and I will follow up.
- Merging moves the `v0` branch via `release.yml`, so every consumer of `@v0` picks this up with no change on their side.