### PR TITLE
feat: Add k6-cloud-run-job composite action

### DIFF
--- a/generic/k6-cloud-run-job/README.md
+++ b/generic/k6-cloud-run-job/README.md
@@ -95,6 +95,64 @@ These are set by the entrypoint:
 | `GRPC_AUTHORITY` | `target-authority` | Empty unless set. |
 | `AUTH_TOKEN` | minted for `target-audience` | Empty if `target-audience` is not set. |
 
+## Slack reporting
+
+Opt in with `slack-notify`. The action reads the run back from the SRE API — the same record
+it just uploaded — and posts through `extenda/actions/slack-notify`.
+
+```yaml
+      - uses: extenda/shared-workflows/generic/k6-cloud-run-job@v0
+        with:
+          mode: execute
+          # ...
+          slack-notify: always                 # never (default) | on-failure | always
+          slack-channel: '#my-clan-alerts'     # empty = clan monitoring channel
+          slack-service-account-key: ${{ secrets.SECRET_AUTH }}
+          sre-api-service-account: my-service@my-clan-prod-1234.iam.gserviceaccount.com
+```
+
+Three outcomes, distinguished from the stored thresholds rather than from an exit code —
+Cloud Run doesn't surface the container's exit code conveniently, and the summary already
+carries the answer:
+
+| Outcome | Meaning | Message |
+|---|---|---|
+| ✅ passed | summary present, every threshold `ok` | metrics table |
+| ⚠️ crossed a threshold | summary present, a threshold failed | which thresholds, then the metrics table |
+| 🔴 no result | nothing reached the SRE API | pointer to the Cloud Run execution logs |
+
+The 🔴 case is the one worth having: it means k6 never ran or never finished — a bad image,
+a missing token, an unreachable service — which is a different problem from missing an SLO.
+
+`on-failure` posts only for the last two.
+
+### Choosing metrics
+
+`slack-metrics` takes one `name:statistic` per line. It defaults to metrics **every** k6 test
+emits, so a caller gets something useful before knowing its own metric names:
+
+```
+iterations:count
+iteration_duration:avg
+iteration_duration:p95
+checks:rate
+```
+
+Add whatever else your test records — `http_req_duration:p95`, `grpc_req_duration:avg`, or a
+custom `Trend`. A metric this run didn't emit is skipped, so the defaults stay safe for both
+HTTP and gRPC tests.
+
+Two constraints come from how the SRE API stores summaries:
+
+- **Statistics are limited to** `avg`, `min`, `med`, `max`, `count`, `rate`, `value`,
+  `passes`, `fails`, `p90`, `p95`. Anything else your test computes is kept in the stored
+  JSON but is not addressable here.
+- **Write `p95`, not k6's `p(95)`** — the SRE API renames them on ingest.
+
+The notification never fails the workflow: the execute step already carries the verdict, and
+a broken Slack post must not change it. A run that can't be read back is reported as 🔴
+rather than silently skipped.
+
 ## Inputs
 
 See [`action.yaml`](action.yaml) for the full list and defaults. The ones worth thinking

--- a/generic/k6-cloud-run-job/README.md
+++ b/generic/k6-cloud-run-job/README.md
@@ -1,0 +1,129 @@
+# k6 Cloud Run Job
+
+Runs a k6 performance test as a Cloud Run Job **inside the VPC**, and reports the summary to
+the SRE API so results can be trended over time.
+
+## When to use this instead of `k6-performance-test`
+
+Use `generic/k6-performance-test` when the service under test is
+reachable from a GitHub runner. It runs k6 on the runner itself and is much simpler.
+
+Use this action when it is not: an internal-only Cloud Run service, a service behind
+Cloud Armor, or anything that only resolves on the clan network. The test then has to run
+from inside the VPC, which means the runner cannot see the results either — the job shares
+no volume with the pipeline that started it, and may not have been started by a pipeline at
+all. So the container uploads its own summary before it exits. There is nothing to fetch.
+
+```
+ GitHub runner                Cloud Run Job (in the VPC)              SRE API
+ ─────────────                ──────────────────────────              ───────
+ build + push image  ─────▶
+ execute --wait      ─────▶   mint ID tokens (target + sre-api)
+                              k6 run --summary-export
+                              POST /api/v1/k6/summary       ─────▶    GCS + Postgres
+                              exit with k6's exit code
+        ◀──────────────────── exit code
+```
+
+## Usage
+
+Deploy the job on merge, execute it on demand — the common split, since a performance test
+against production usually should not run on every push:
+
+```yaml
+  performance-job-build:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Produce the k6 script and any data it opens, however your project does that.
+      - run: ./scripts/generate-k6-assets.sh
+
+      - uses: extenda/shared-workflows/generic/k6-cloud-run-job@v0
+        with:
+          mode: deploy
+          service-account-key: ${{ secrets.GCLOUD_AUTH_PROD }}
+          project-id: my-clan-prod-1234
+          job-name: my-service-performance-test
+          image: eu.gcr.io/extenda/my-service-performance
+          assets-path: target/k6
+          script: my-test.js
+          job-service-account: my-service@my-clan-prod-1234.iam.gserviceaccount.com
+          target-host: my-service.internal:80
+          target-audience: my-service
+          service-name: my-service
+          test-name: my-test
+          environment: production
+          clan: my-clan
+```
+
+```yaml
+# .github/workflows/run-performance-test.yaml
+on: workflow_dispatch
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: extenda/shared-workflows/generic/k6-cloud-run-job@v0
+        with:
+          mode: execute
+          service-account-key: ${{ secrets.GCLOUD_AUTH_PROD }}
+          project-id: my-clan-prod-1234
+          job-name: my-service-performance-test
+          service-name: my-service
+          test-name: my-test
+          environment: production
+          clan: my-clan
+```
+
+`mode: both` builds, deploys and runs in one step, for a test cheap enough to run on
+every merge.
+
+## What your k6 script gets
+
+The action generates the Dockerfile, so you do not write one. Your `assets-path` directory
+is copied to `/k6-tests` and the script is run from there — `open('./requests.json')` and
+similar relative reads work as they do locally.
+
+These are set by the entrypoint:
+
+| k6 env var | From | Notes |
+|---|---|---|
+| `TARGET_HOST` | `target-host` | Same value as `GRPC_HOST`; use whichever fits your protocol. |
+| `GRPC_HOST` | `target-host` | |
+| `GRPC_AUTHORITY` | `target-authority` | Empty unless set. |
+| `AUTH_TOKEN` | minted for `target-audience` | Empty if `target-audience` is not set. |
+
+## Inputs
+
+See [`action.yaml`](action.yaml) for the full list and defaults. The ones worth thinking
+about:
+
+| Input | Notes |
+|---|---|
+| `mode` | `deploy`, `execute`, or `both`. Default `both`. |
+| `service-name`, `test-name`, `environment`, `clan`, `project-id` | The **partition key** behind `GET /k6/trends`. Changing any of them starts a new series, so pick them once and keep them stable. |
+| `assets-path` | Must exist when the action runs. Generate it in an earlier step. |
+| `job-service-account` | Needs access to the service under test. Its project must be one the SRE API accepts. |
+| `target-audience` | Leave empty if the service under test needs no identity token. |
+| `max-retries` | Keep at `0`. A retry replays the whole load and uploads a second summary. |
+| `extra-dockerfile-lines` | Escape hatch for an image that needs more than `curl`. |
+
+## Reading the results
+
+```bash
+curl "https://sre-api.retailsvc.com/api/v1/k6/trends?serviceName=my-service&testName=my-test&environment=production&statistic=p95"
+```
+
+## Notes and known gaps
+
+- **A threshold breach fails the workflow.** The entrypoint exits with k6's own exit code
+  and `execute` uses `--wait`, so a crossed threshold (exit 99) surfaces as a red step.
+- **An upload failure does not.** It logs a `WARN` and leaves the exit code alone: a flaky
+  SRE API must not turn a healthy run red, nor mask a threshold breach.
+- **`duration_ms` is currently null.** The SRE API reads `state.testRunDurationMs`, which
+  `--summary-export` does not emit. Emitting the richer `handleSummary` format instead would
+  fix it, at the cost of changing the JSON shape any existing consumer parses.
+- **Only `p90` and `p95` become queryable columns.** Other percentiles survive in the stored
+  JSON and as threshold pass/fail, but not as trendable numbers.

--- a/generic/k6-cloud-run-job/README.md
+++ b/generic/k6-cloud-run-job/README.md
@@ -167,6 +167,7 @@ about:
 | `target-audience` | Leave empty if the service under test needs no identity token. |
 | `max-retries` | Keep at `0`. A retry replays the whole load and uploads a second summary. |
 | `extra-dockerfile-lines` | Escape hatch for an image that needs more than `curl`. |
+| `k6-version` | The `grafana/k6` base image tag. **Not dependabot-visible** — the Dockerfile is generated, so there is no `FROM` line for it to find. Bump by hand. |
 
 ## Reading the results
 

--- a/generic/k6-cloud-run-job/action.yaml
+++ b/generic/k6-cloud-run-job/action.yaml
@@ -112,9 +112,12 @@ inputs:
     required: false
     default: script.js
   k6-version:
-    description: Tag of the grafana/k6 base image.
+    description: >
+      Tag of the grafana/k6 base image. Because the Dockerfile is generated rather than
+      checked in, dependabot cannot see this value -- it has to be bumped by hand when a
+      new k6 is released.
     required: false
-    default: 2.1.0
+    default: 2.2.0
   extra-dockerfile-lines:
     description: >
       Extra Dockerfile instructions inserted before the assets are copied, for images

--- a/generic/k6-cloud-run-job/action.yaml
+++ b/generic/k6-cloud-run-job/action.yaml
@@ -49,6 +49,49 @@ inputs:
     required: false
     default: hiiretail-sre-api
 
+  # --- Slack reporting (mode execute/both) -------------------------------------------
+  slack-notify:
+    description: >
+      When to post the result to Slack: never, on-failure, or always. Reads the run back
+      from the SRE API, so it needs sre-api-service-account and slack-service-account-key.
+    required: false
+    default: never
+  slack-channel:
+    description: >
+      Channel to post to. Leave empty to use the clan's monitoring channel, which
+      extenda/actions/slack-notify resolves from the clan_slack_channel secret. A private
+      channel needs the SlackNotifications app invited first.
+    required: false
+    default: ''
+  slack-service-account-key:
+    description: >
+      Service account key for extenda/actions/slack-notify, which reads the Slack token
+      from Secret Manager. Usually a different key from service-account-key.
+    required: false
+    default: ''
+  sre-api-service-account:
+    description: >
+      Service account to mint the SRE API read token as. Typically the same one the job
+      runs as, since its project is already accepted by the SRE API.
+    required: false
+    default: ''
+  slack-metrics:
+    description: >
+      Metrics to include in a successful message, one `name:statistic` per line. Defaults
+      to metrics every k6 test emits, so a new caller gets something useful without
+      knowing its own metric names. Add protocol-specific ones (http_req_duration,
+      grpc_req_duration) or your own custom trends.
+
+      Statistic must be one the SRE API stores: avg, min, med, max, count, rate, value,
+      passes, fails, p90, p95. Note p90/p95, not k6's p(90)/p(95). A metric that the run
+      did not emit is skipped rather than failing the step.
+    required: false
+    default: |
+      iterations:count
+      iteration_duration:avg
+      iteration_duration:p95
+      checks:rate
+
   # --- Image (mode deploy/both) ------------------------------------------------------
   image:
     description: Image repository to push to, without a tag.
@@ -153,6 +196,9 @@ runs:
         SCRIPT: ${{ inputs.script }}
         TARGET_HOST: ${{ inputs.target-host }}
         JOB_SERVICE_ACCOUNT: ${{ inputs.job-service-account }}
+        SLACK_NOTIFY: ${{ inputs.slack-notify }}
+        SLACK_SERVICE_ACCOUNT_KEY: ${{ inputs.slack-service-account-key }}
+        SRE_API_SERVICE_ACCOUNT: ${{ inputs.sre-api-service-account }}
       run: |
         set -uo pipefail
         fail=0
@@ -181,6 +227,19 @@ runs:
             fail=1
           fi
         fi
+
+        case "$SLACK_NOTIFY" in
+          never) ;;
+          always|on-failure)
+            if [ "$MODE" = deploy ]; then
+              echo "::error::slack-notify has nothing to report in mode 'deploy'"
+              fail=1
+            fi
+            require slack-service-account-key "$SLACK_SERVICE_ACCOUNT_KEY"
+            require sre-api-service-account "$SRE_API_SERVICE_ACCOUNT"
+            ;;
+          *) echo "::error::slack-notify must be never, on-failure or always, got '$SLACK_NOTIFY'"; fail=1 ;;
+        esac
 
         exit $fail
 
@@ -308,6 +367,7 @@ runs:
 
     - name: Execute Cloud Run Job
       if: inputs.mode != 'deploy'
+      id: execute
       shell: bash
       env:
         JOB_NAME: ${{ inputs.job-name }}
@@ -316,6 +376,10 @@ runs:
         SRE_API_URL: ${{ inputs.sre-api-url }}
       run: |
         set -euo pipefail
+
+        # Read back only summaries written after this moment, so a concurrent run's result
+        # cannot be mistaken for ours.
+        echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
         # --wait blocks until the execution finishes and exits non-zero if it failed, so a
         # k6 threshold breach fails this step. The execution name comes back from the same
@@ -329,3 +393,131 @@ runs:
 
         echo "EXECUTION_ID=$EXECUTION_ID" >> "$GITHUB_ENV"
         echo "Execution $EXECUTION_ID finished. The job uploaded its summary to ${SRE_API_URL}."
+
+    # The steps below run even when the execution failed -- a failed run is exactly when a
+    # notification matters most. They never fail the job themselves: the execute step above
+    # already carries the verdict, and a broken notification must not change it.
+    - name: Get SRE API read token
+      if: ${{ !cancelled() && inputs.mode != 'deploy' && inputs.slack-notify != 'never' }}
+      uses: extenda/actions/identity-token@v0
+      with:
+        service-account-key: ${{ inputs.service-account-key }}
+        service-account: ${{ inputs.sre-api-service-account }}
+        audiences: ${{ inputs.sre-api-audience }}
+
+    - name: Compose Slack message
+      if: ${{ !cancelled() && inputs.mode != 'deploy' && inputs.slack-notify != 'never' }}
+      id: slack-message
+      shell: bash
+      env:
+        SRE_API_URL: ${{ inputs.sre-api-url }}
+        SERVICE_NAME: ${{ inputs.service-name }}
+        TEST_NAME: ${{ inputs.test-name }}
+        PROJECT_ID: ${{ inputs.project-id }}
+        ENVIRONMENT: ${{ inputs.environment }}
+        CLAN: ${{ inputs.clan }}
+        SLACK_METRICS: ${{ inputs.slack-metrics }}
+        SLACK_NOTIFY: ${{ inputs.slack-notify }}
+        STARTED_AT: ${{ steps.execute.outputs.started_at }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -uo pipefail
+
+        QUERY="serviceName=${SERVICE_NAME}&testName=${TEST_NAME}&projectId=${PROJECT_ID}"
+        QUERY="${QUERY}&environment=${ENVIRONMENT}&clan=${CLAN}&fromDate=${STARTED_AT}&limit=1"
+
+        if ! curl --fail --silent --show-error --max-time 30 --retry 2 \
+          -H "Authorization: Bearer ${IDENTITY_TOKEN}" \
+          "${SRE_API_URL}/api/v1/k6/summary?${QUERY}" -o summary.json; then
+          echo "::warning::could not read the run back from the SRE API"
+          echo '{"items":[]}' > summary.json
+        fi
+
+        # No summary means k6 never produced results: a bad image, a missing token, an
+        # unreachable service. That is a different failure from missing an SLO, and the
+        # message says so. Distinguishing them from the stored thresholds avoids having to
+        # dig the container exit code out of the Cloud Run execution.
+        if [ "$(jq '.items | length' summary.json)" -eq 0 ]; then
+          OUTCOME=failed
+        elif [ "$(jq '[.items[0].metrics[]?.thresholds[]? | select(.ok == false)] | length' summary.json)" -gt 0 ]; then
+          OUTCOME=breached
+        else
+          OUTCOME=passed
+        fi
+        echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+
+        if [ "$SLACK_NOTIFY" = on-failure ] && [ "$OUTCOME" = passed ]; then
+          echo "notify=false" >> "$GITHUB_OUTPUT"
+          echo "Run passed and slack-notify is on-failure; not posting."
+          exit 0
+        fi
+        echo "notify=true" >> "$GITHUB_OUTPUT"
+
+        case "$OUTCOME" in
+          passed)   HEADLINE=":white_check_mark: *${SERVICE_NAME}* k6 \`${TEST_NAME}\` passed" ;;
+          breached) HEADLINE=":warning: *${SERVICE_NAME}* k6 \`${TEST_NAME}\` crossed a threshold" ;;
+          failed)   HEADLINE=":red_circle: *${SERVICE_NAME}* k6 \`${TEST_NAME}\` did not produce a result" ;;
+        esac
+
+        {
+          echo "${HEADLINE}  _(${ENVIRONMENT})_"
+          echo
+
+          if [ "$OUTCOME" = failed ]; then
+            echo "No summary reached the SRE API for this run, so k6 either never started or"
+            echo "never finished. Check the Cloud Run execution logs."
+          else
+            if [ "$OUTCOME" = breached ]; then
+              echo '```'
+              jq -r '.items[0].metrics[]? as $m
+                     | $m.thresholds[]? | select(.ok == false)
+                     | "FAILED  \($m.name)  \(.expr)"' summary.json
+              echo '```'
+            fi
+
+            # A metric the run did not emit is skipped rather than printed as null: the
+            # defaults are protocol-agnostic, so a caller will legitimately not have all of
+            # them.
+            TABLE="$(
+              while IFS= read -r line; do
+                [ -n "$line" ] || continue
+                name="${line%%:*}"
+                stat="${line##*:}"
+                jq -r --arg n "$name" --arg s "$stat" '
+                  (.items[0].metrics[]? | select(.name == $n) | .values[$s]) as $v
+                  | if $v == null then empty
+                    else "\($n) \($s) \($v | if type != "number" then .
+                                             elif (if . < 0 then -. else . end) >= 1 then (.*100|round/100)
+                                             else (.*10000|round/10000) end)"
+                    end' summary.json
+              done <<< "$SLACK_METRICS"
+            )"
+
+            if [ -n "$TABLE" ]; then
+              echo '```'
+              printf '%s\n' "$TABLE" | awk '{printf "%-24s %-6s %s\n", $1, $2, $3}'
+              echo '```'
+            else
+              echo "_No matching metrics in the summary. Check the slack-metrics input._"
+            fi
+          fi
+
+          echo "<${RUN_URL}|GitHub run>"
+        } > slack-text.md
+
+        echo "Composed message:"; sed 's/^/  /' slack-text.md
+
+        {
+          echo "text<<SLACK_EOF"
+          cat slack-text.md
+          echo "SLACK_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Notify Slack
+      if: ${{ !cancelled() && inputs.mode != 'deploy' && inputs.slack-notify != 'never' && steps.slack-message.outputs.notify == 'true' }}
+      continue-on-error: true
+      uses: extenda/actions/slack-notify@v0
+      with:
+        service-account-key: ${{ inputs.slack-service-account-key }}
+        channel: ${{ inputs.slack-channel }}
+        text: ${{ steps.slack-message.outputs.text }}

--- a/generic/k6-cloud-run-job/action.yaml
+++ b/generic/k6-cloud-run-job/action.yaml
@@ -1,0 +1,331 @@
+name: k6 Cloud Run Job
+description: >
+  Run a k6 performance test as a Cloud Run Job inside the VPC, against a service that is
+  not reachable from a GitHub runner, and report the summary to the SRE API.
+
+inputs:
+  mode:
+    description: >
+      deploy (build the image and create or update the job), execute (run the existing job),
+      or both.
+    required: false
+    default: both
+
+  service-account-key:
+    description: GCP service account key used by the pipeline.
+    required: true
+  project-id:
+    description: GCP project the Cloud Run Job lives in.
+    required: true
+  region:
+    description: Region the Cloud Run Job lives in.
+    required: false
+    default: europe-west1
+  job-name:
+    description: Name of the Cloud Run Job.
+    required: true
+
+  # --- Reported to the SRE API -------------------------------------------------------
+  # These, with project-id, are the partition key behind GET /k6/trends. Changing any of
+  # them starts a new series, so keep them stable once a test has history.
+  service-name:
+    description: Service under test, reported as X-Service-Name.
+    required: true
+  test-name:
+    description: Name of this test, reported as X-Test-Name. Stable across runs.
+    required: true
+  environment:
+    description: Environment the test ran against, reported as X-Environment.
+    required: true
+  clan:
+    description: Owning clan, reported as X-Clan.
+    required: true
+  sre-api-url:
+    description: Base URL of the SRE API.
+    required: false
+    default: https://sre-api.retailsvc.com
+  sre-api-audience:
+    description: Identity token audience accepted by the SRE API.
+    required: false
+    default: hiiretail-sre-api
+
+  # --- Image (mode deploy/both) ------------------------------------------------------
+  image:
+    description: Image repository to push to, without a tag.
+    required: false
+    default: ''
+  image-tag:
+    description: Tag for the image. Defaults to the commit SHA.
+    required: false
+    default: ''
+  assets-path:
+    description: >
+      Directory holding the k6 script and anything it opens (payload files, protos).
+      Copied to /k6-tests in the image.
+    required: false
+    default: ''
+  script:
+    description: Filename of the k6 script inside assets-path.
+    required: false
+    default: script.js
+  k6-version:
+    description: Tag of the grafana/k6 base image.
+    required: false
+    default: 2.1.0
+  extra-dockerfile-lines:
+    description: >
+      Extra Dockerfile instructions inserted before the assets are copied, for images
+      that need more than curl. Rarely needed.
+    required: false
+    default: ''
+  attest:
+    description: Attest the image for binary authorization.
+    required: false
+    default: 'true'
+
+  # --- Service under test (mode deploy/both) -----------------------------------------
+  target-host:
+    description: >
+      Host the k6 script targets, passed to the script as both TARGET_HOST and GRPC_HOST.
+      Usually only resolvable from inside the VPC.
+    required: false
+    default: ''
+  target-authority:
+    description: gRPC authority override, passed as GRPC_AUTHORITY. Optional.
+    required: false
+    default: ''
+  target-audience:
+    description: >
+      Identity token audience for the service under test, passed to the script as
+      AUTH_TOKEN. Leave empty for a service that needs no token.
+    required: false
+    default: ''
+
+  # --- Job configuration (mode deploy/both) ------------------------------------------
+  job-service-account:
+    description: >
+      Service account the job runs as. It needs access to the service under test, and its
+      project must be accepted by the SRE API.
+    required: false
+    default: ''
+  network:
+    description: VPC network the job attaches to.
+    required: false
+    default: clan-network
+  subnet:
+    description: Subnet the job attaches to.
+    required: false
+    default: cloudrun-subnet
+  vpc-egress:
+    description: >
+      VPC egress setting. private-ranges-only keeps internal traffic on the VPC while
+      letting the summary upload reach the SRE API directly.
+    required: false
+    default: private-ranges-only
+  cpu:
+    description: vCPUs for the job. k6 is CPU-bound at higher VU counts.
+    required: false
+    default: '4'
+  memory:
+    description: Memory for the job.
+    required: false
+    default: 2Gi
+  task-timeout:
+    description: Task timeout for the job.
+    required: false
+    default: 1h
+  max-retries:
+    description: >
+      Retries for a failed task. Keep at 0: a retry replays the full load against the
+      service under test and uploads a second summary.
+    required: false
+    default: '0'
+
+runs:
+  using: composite
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        IMAGE: ${{ inputs.image }}
+        ASSETS_PATH: ${{ inputs.assets-path }}
+        SCRIPT: ${{ inputs.script }}
+        TARGET_HOST: ${{ inputs.target-host }}
+        JOB_SERVICE_ACCOUNT: ${{ inputs.job-service-account }}
+      run: |
+        set -uo pipefail
+        fail=0
+        require() {
+          if [ -z "$2" ]; then
+            echo "::error::input '$1' is required when mode is '$MODE'"
+            fail=1
+          fi
+        }
+
+        case "$MODE" in
+          deploy|execute|both) ;;
+          *) echo "::error::mode must be deploy, execute or both, got '$MODE'"; exit 1 ;;
+        esac
+
+        if [ "$MODE" != execute ]; then
+          require image "$IMAGE"
+          require assets-path "$ASSETS_PATH"
+          require target-host "$TARGET_HOST"
+          require job-service-account "$JOB_SERVICE_ACCOUNT"
+          if [ -n "$ASSETS_PATH" ] && [ ! -d "$ASSETS_PATH" ]; then
+            echo "::error::assets-path '$ASSETS_PATH' is not a directory. Generate the k6 assets before this step."
+            fail=1
+          elif [ -n "$ASSETS_PATH" ] && [ ! -f "$ASSETS_PATH/$SCRIPT" ]; then
+            echo "::error::script '$SCRIPT' not found in '$ASSETS_PATH'"
+            fail=1
+          fi
+        fi
+
+        exit $fail
+
+    - name: Set up gcloud
+      uses: extenda/actions/setup-gcloud@v0
+      with:
+        service-account-key: ${{ inputs.service-account-key }}
+
+    - name: Build and push k6 image
+      if: inputs.mode != 'execute'
+      id: build
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        IMAGE_TAG: ${{ inputs.image-tag || github.sha }}
+        ASSETS_PATH: ${{ inputs.assets-path }}
+        K6_VERSION: ${{ inputs.k6-version }}
+        EXTRA_LINES: ${{ inputs.extra-dockerfile-lines }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+
+        # Build from a generated context so the entrypoint always comes from this action.
+        # A per-repo Dockerfile would pin a copy of the upload logic that never gets fixed.
+        BUILD_DIR="$(mktemp -d)"
+        mkdir -p "$BUILD_DIR/assets"
+        cp -R "$ASSETS_PATH/." "$BUILD_DIR/assets/"
+        cp "$ACTION_PATH/entrypoint.sh" "$BUILD_DIR/entrypoint.sh"
+
+        {
+          echo "FROM grafana/k6:${K6_VERSION}"
+          echo "USER root"
+          echo "RUN apk add --no-cache curl"
+          if [ -n "$EXTRA_LINES" ]; then echo "$EXTRA_LINES"; fi
+          echo "COPY assets /k6-tests"
+          echo "COPY entrypoint.sh /k6-tests/entrypoint.sh"
+          echo "RUN chmod +x /k6-tests/entrypoint.sh \\"
+          echo " && adduser --disabled-password --gecos '' k6user \\"
+          echo " && chown -R k6user:k6user /k6-tests"
+          echo "USER k6user"
+          echo "WORKDIR /k6-tests"
+          echo 'ENTRYPOINT ["/k6-tests/entrypoint.sh"]'
+        } > "$BUILD_DIR/Dockerfile"
+
+        echo "Generated Dockerfile:"
+        sed 's/^/  /' "$BUILD_DIR/Dockerfile"
+
+        gcloud --quiet auth configure-docker "${IMAGE%%/*}"
+        docker build -t "${IMAGE}:${IMAGE_TAG}" "$BUILD_DIR"
+        docker push "${IMAGE}:${IMAGE_TAG}"
+
+        echo "image=${IMAGE}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+    - name: Attest image
+      if: inputs.mode != 'execute' && inputs.attest == 'true'
+      uses: extenda/actions/binary-auth-attestation@v0
+      with:
+        image-path: ${{ inputs.image }}
+        service-account-key: ${{ inputs.service-account-key }}
+
+    - name: Create or update Cloud Run Job
+      if: inputs.mode != 'execute'
+      shell: bash
+      env:
+        IMAGE: ${{ steps.build.outputs.image }}
+        JOB_NAME: ${{ inputs.job-name }}
+        PROJECT_ID: ${{ inputs.project-id }}
+        REGION: ${{ inputs.region }}
+        NETWORK: ${{ inputs.network }}
+        SUBNET: ${{ inputs.subnet }}
+        VPC_EGRESS: ${{ inputs.vpc-egress }}
+        JOB_SERVICE_ACCOUNT: ${{ inputs.job-service-account }}
+        TASK_TIMEOUT: ${{ inputs.task-timeout }}
+        CPU: ${{ inputs.cpu }}
+        MEMORY: ${{ inputs.memory }}
+        MAX_RETRIES: ${{ inputs.max-retries }}
+        SERVICE_NAME: ${{ inputs.service-name }}
+        TEST_NAME: ${{ inputs.test-name }}
+        ENVIRONMENT: ${{ inputs.environment }}
+        CLAN: ${{ inputs.clan }}
+        SCRIPT: ${{ inputs.script }}
+        TARGET_HOST: ${{ inputs.target-host }}
+        TARGET_AUTHORITY: ${{ inputs.target-authority }}
+        TARGET_AUDIENCE: ${{ inputs.target-audience }}
+        SRE_API_URL: ${{ inputs.sre-api-url }}
+        SRE_API_AUDIENCE: ${{ inputs.sre-api-audience }}
+      run: |
+        set -euo pipefail
+
+        # '^@^' sets @ as the separator so values may contain commas.
+        ENV_VARS="^@^SERVICE_NAME=${SERVICE_NAME}"
+        ENV_VARS="${ENV_VARS}@PROJECT_ID=${PROJECT_ID}"
+        ENV_VARS="${ENV_VARS}@TEST_NAME=${TEST_NAME}"
+        ENV_VARS="${ENV_VARS}@ENVIRONMENT=${ENVIRONMENT}"
+        ENV_VARS="${ENV_VARS}@CLAN=${CLAN}"
+        ENV_VARS="${ENV_VARS}@K6_SCRIPT=${SCRIPT}"
+        ENV_VARS="${ENV_VARS}@TARGET_HOST=${TARGET_HOST}"
+        ENV_VARS="${ENV_VARS}@TARGET_AUTHORITY=${TARGET_AUTHORITY}"
+        ENV_VARS="${ENV_VARS}@TARGET_AUDIENCE=${TARGET_AUDIENCE}"
+        ENV_VARS="${ENV_VARS}@SRE_API_URL=${SRE_API_URL}"
+        ENV_VARS="${ENV_VARS}@SRE_API_AUDIENCE=${SRE_API_AUDIENCE}"
+
+        if gcloud run jobs describe "$JOB_NAME" --region "$REGION" --project "$PROJECT_ID" >/dev/null 2>&1; then
+          echo "Job $JOB_NAME exists, updating it."
+          VERB=update
+        else
+          echo "Job $JOB_NAME does not exist, creating it."
+          VERB=create
+        fi
+
+        gcloud run jobs "$VERB" "$JOB_NAME" \
+          --image "$IMAGE" \
+          --region "$REGION" \
+          --project "$PROJECT_ID" \
+          --network "$NETWORK" \
+          --subnet "$SUBNET" \
+          --vpc-egress "$VPC_EGRESS" \
+          --service-account "$JOB_SERVICE_ACCOUNT" \
+          --task-timeout "$TASK_TIMEOUT" \
+          --cpu "$CPU" \
+          --memory "$MEMORY" \
+          --max-retries "$MAX_RETRIES" \
+          --set-env-vars "$ENV_VARS" \
+          --quiet
+
+    - name: Execute Cloud Run Job
+      if: inputs.mode != 'deploy'
+      shell: bash
+      env:
+        JOB_NAME: ${{ inputs.job-name }}
+        PROJECT_ID: ${{ inputs.project-id }}
+        REGION: ${{ inputs.region }}
+        SRE_API_URL: ${{ inputs.sre-api-url }}
+      run: |
+        set -euo pipefail
+
+        # --wait blocks until the execution finishes and exits non-zero if it failed, so a
+        # k6 threshold breach fails this step. The execution name comes back from the same
+        # call; listing executions afterwards would race with concurrent runs.
+        EXECUTION_ID="$(gcloud run jobs execute "$JOB_NAME" \
+          --region "$REGION" \
+          --project "$PROJECT_ID" \
+          --wait \
+          --quiet \
+          --format='value(metadata.name)')"
+
+        echo "EXECUTION_ID=$EXECUTION_ID" >> "$GITHUB_ENV"
+        echo "Execution $EXECUTION_ID finished. The job uploaded its summary to ${SRE_API_URL}."

--- a/generic/k6-cloud-run-job/entrypoint.sh
+++ b/generic/k6-cloud-run-job/entrypoint.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+#
+# Entrypoint for the k6 performance-test image built by the k6-cloud-run-job action.
+#
+# Runs the k6 script against the service under test, then pushes the end-of-test
+# summary to the SRE API so results can be trended over time.
+#
+# Nothing outside the container can retrieve the summary: a Cloud Run Job shares no
+# volume with the pipeline that started it, and the job may not have been started by a
+# pipeline at all. So the upload has to happen here, before we exit.
+#
+# Every setting is supplied as an environment variable on the job by the action.
+
+set -u
+
+# Reported to the SRE API. Together with the test name these five values are the
+# partition key behind GET /k6/trends, so they must stay stable across runs.
+SERVICE_NAME="${SERVICE_NAME:?SERVICE_NAME is required}"
+PROJECT_ID="${PROJECT_ID:?PROJECT_ID is required}"
+TEST_NAME="${TEST_NAME:?TEST_NAME is required}"
+ENVIRONMENT="${ENVIRONMENT:?ENVIRONMENT is required}"
+CLAN="${CLAN:?CLAN is required}"
+
+K6_SCRIPT="${K6_SCRIPT:?K6_SCRIPT is required}"
+SUMMARY_FILE="${SUMMARY_FILE:-/tmp/${TEST_NAME}-summary.json}"
+
+# Service under test. TARGET_HOST is typically only resolvable from inside the VPC.
+TARGET_HOST="${TARGET_HOST:?TARGET_HOST is required}"
+TARGET_AUTHORITY="${TARGET_AUTHORITY:-}"
+TARGET_AUDIENCE="${TARGET_AUDIENCE:-}"
+
+SRE_API_URL="${SRE_API_URL:-https://sre-api.retailsvc.com}"
+SRE_API_AUDIENCE="${SRE_API_AUDIENCE:-hiiretail-sre-api}"
+
+METADATA_URL="http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity"
+
+# Mint a Google-signed ID token for the given audience from the metadata server.
+fetch_id_token() {
+  curl --silent --fail --max-time 10 \
+    -H "Metadata-Flavor: Google" \
+    "${METADATA_URL}?audience=$1"
+}
+
+# Push the summary to the SRE API. Never fatal: a flaky upload must not turn a healthy
+# performance run red, and must not mask a k6 threshold breach.
+upload_summary() {
+  if [ ! -s "${SUMMARY_FILE}" ]; then
+    echo "WARN: no summary at ${SUMMARY_FILE}, skipping upload"
+    return
+  fi
+
+  sre_token=$(fetch_id_token "${SRE_API_AUDIENCE}")
+  if [ -z "${sre_token}" ]; then
+    echo "WARN: could not mint an identity token for '${SRE_API_AUDIENCE}', skipping upload"
+    return
+  fi
+
+  if curl --fail --silent --show-error --max-time 60 --retry 2 --retry-connrefused \
+    -X POST "${SRE_API_URL}/api/v1/k6/summary" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${sre_token}" \
+    -H "X-Service-Name: ${SERVICE_NAME}" \
+    -H "X-Project-Id: ${PROJECT_ID}" \
+    -H "X-Test-Name: ${TEST_NAME}" \
+    -H "X-Environment: ${ENVIRONMENT}" \
+    -H "X-Clan: ${CLAN}" \
+    --data-binary "@${SUMMARY_FILE}"; then
+    echo "Uploaded k6 summary for ${SERVICE_NAME}/${TEST_NAME} (${ENVIRONMENT})"
+  else
+    echo "WARN: failed to upload k6 summary to ${SRE_API_URL}"
+  fi
+}
+
+# The service under test is usually IAM-protected, so mint a token for it up front.
+# Scripts that do not need one can leave TARGET_AUDIENCE empty.
+target_token=''
+if [ -n "${TARGET_AUDIENCE}" ]; then
+  target_token=$(fetch_id_token "${TARGET_AUDIENCE}")
+  if [ -z "${target_token}" ]; then
+    echo "ERROR: could not mint an identity token for '${TARGET_AUDIENCE}'"
+    exit 1
+  fi
+fi
+
+k6 run \
+  --summary-export="${SUMMARY_FILE}" \
+  -e GRPC_HOST="${TARGET_HOST}" \
+  -e TARGET_HOST="${TARGET_HOST}" \
+  -e GRPC_AUTHORITY="${TARGET_AUTHORITY}" \
+  -e AUTH_TOKEN="${target_token}" \
+  "${K6_SCRIPT}"
+k6_exit=$?
+
+upload_summary
+
+exit "${k6_exit}"


### PR DESCRIPTION
Adds `generic/k6-cloud-run-job`: runs a k6 performance test as a Cloud Run Job **inside the VPC** and reports the summary to the SRE API.

## Why this and not `k6-performance-test`

The existing runner-side approach only works when a GitHub runner can reach the service. An internal-only Cloud Run service, or one behind Cloud Armor, has to be tested from inside the VPC — and then the runner can't collect the results either. The job shares no volume with the pipeline that started it, and may not have been started by a pipeline at all.

So the container uploads its own summary before exiting. There is nothing to fetch. That's the part that isn't obvious from the outside, and the reason a shared building block is worth having rather than each clan rediscovering it.

```
 GitHub runner                Cloud Run Job (in the VPC)              SRE API
 build + push image  ─────▶
 execute --wait      ─────▶   mint ID tokens (target + sre-api)
                              k6 run --summary-export
                              POST /api/v1/k6/summary       ─────▶    GCS + Postgres
                              exit with k6's exit code
        ◀──────────────────── exit code
```

## Design notes for reviewers

**The action generates the Dockerfile and injects its own entrypoint**, rather than building from a Dockerfile in the calling repo. This is the main thing worth pushing back on if you disagree: it costs callers some flexibility, but a per-repo Dockerfile pins a copy of the upload logic that never gets fixed, which defeats the point of sharing it. `extra-dockerfile-lines` is the escape hatch.

**One action with a `mode` input** rather than separate deploy/execute actions. Callers usually deploy the job on merge and execute it on demand, but a cheap test can do both in one step.

**`service-name`, `test-name`, `environment`, `clan` and `project-id` are all required.** They're the partition key behind `GET /k6/trends`, so changing one later starts a new series. Making them required forces a caller to choose deliberately instead of inheriting a default that quietly fragments their history.

**Inputs reach shell via `env:`, never `${{ }}` inside `run:`** — this repo is public and other teams call it.

## Verification

No GCP calls. I built the exact Dockerfile the action generates and ran the entrypoint in `grafana/k6:2.1.0` against a stub metadata server and SRE API:

| case | result |
|---|---|
| happy path | exit 0, uploaded, all five headers correct |
| k6 threshold breach | exit 99, **and still uploaded** — a bad run belongs in the trend |
| no `target-audience` | exit 0, mints only the SRE API token |
| SRE API returns 500 / unreachable | exit 0 + `WARN` — a flaky upload can't turn a healthy run red |
| missing required env var | fails before k6 starts |

The gcloud steps and the composite wiring have **not** been executed — that needs a real run, which is what the promotion-engine PR below is for.

## Known gaps, documented in the README

- `duration_ms` lands null: the SRE API reads `state.testRunDurationMs`, which `--summary-export` doesn't emit. Moving to `handleSummary` would fix it but changes the JSON shape existing consumers parse.
- Only `p90`/`p95` become queryable columns. Other percentiles survive in the stored JSON and as threshold pass/fail, but aren't trendable.

## Coordination

There's an unmerged `feature/k6-composite` branch adding `generic/k6-performance-test`, the runner-side variant — one commit from 2025-10-10, never PR'd, no adopters (org-wide code search finds none). My README refers to it as the simpler sibling for the runner-reachable case. **Two unmerged k6 actions is a worse outcome than one**, so these should probably land together or be folded into one PR. Happy to do either.

First consumer: extenda/hiiretail-promotion-engine#737